### PR TITLE
fix: 웹 스타일 수정 및 수상이력 삭제 로직 개선

### DIFF
--- a/apps/admin/src/pages/Awards/index.tsx
+++ b/apps/admin/src/pages/Awards/index.tsx
@@ -242,8 +242,20 @@ export const Awards = () => {
     if (pendingDeleteId === null) return;
 
     try {
-      await deleteAwardMutation.mutateAsync({ awardId: pendingDeleteId });
-      setPendingDeleteId(null);
+      await deleteAwardMutation.mutateAsync(
+        { awardId: pendingDeleteId },
+        {
+          onSuccess: () => {
+            setPendingDeleteId(null);
+            setIsDeleteOpen(false);
+            toast.success("수상이력이 삭제되었습니다.");
+          },
+          onError: (error) => {
+            console.error(error);
+            toast.error("수상이력 삭제에 실패했습니다.");
+          },
+        },
+      );
     } catch (error) {
       console.error(error);
       toast.error("수상이력 삭제에 실패했습니다.");

--- a/apps/web/src/components/News/NewsCard.tsx
+++ b/apps/web/src/components/News/NewsCard.tsx
@@ -30,7 +30,7 @@ const NewsCard = ({ article, year }: NewsCardProps) => {
         className="w-full flex flex-col items-start gap-4"
       >
         <div className="flex flex-col text-theme-default leading-theme-description w-full indent-1 xs:hidden @container">
-          <div className="mb-2.5">
+          <div className="flex flex-row mb-2.5 justify-between items-start">
             <div className="flex flex-col items-normal justify-normal">
               <div className={cn("flex flex-row gap-4 items-center")}>
                 <h3 className="indent-0 text-theme-description leading-theme-description font-bold">
@@ -52,55 +52,76 @@ const NewsCard = ({ article, year }: NewsCardProps) => {
                 </span>
               </div>
             </div>
-          </div>
-        </div>
-        {article.images[0] && (
-          <div className="w-full h-full flex items-center justify-center relative">
-            {isLoading ? (
-              <picture>
-                <img
-                  loading="lazy"
-                  alt={article.title + article.author}
-                  src={article.images[0].originSrc}
-                  className="w-full h-full bg-black object-contain"
-                />
-                <source
-                  srcSet={
-                    article.images[0].smallSrc || article.images[0].originSrc
-                  }
-                  media="(max-width: 640px)"
-                />
-              </picture>
-            ) : (
-              <SkeletonThumbnail />
-            )}
-            <picture>
-              <img
-                alt={article.title + article.author}
-                src={article.images[0].originSrc}
-                style={{ display: "none" }}
-                onLoad={handleLoding}
-              />
-              <source
-                srcSet={
-                  article.images[0].smallSrc || article.images[0].originSrc
-                }
-                media="(max-width: 640px)"
-              />
-            </picture>
-            <div className="flex flex-col items-normal justify-normal">
-              <div className="text-theme-description leading-theme-description font-bold pt-2 text-ellipsis overflow-hidden whitespace-nowrap hidden xs:block">
-                {article.title}
-              </div>
-              <div className="text-theme-tiny leading-theme-tiny text-theme-grey hidden xs:block">
-                {article.author}
-              </div>
-              <div className="text-theme-tiny leading-theme-tiny text-theme-grey hidden xs:block">
-                {article.tags}
-              </div>
+            <div>
+              {article.images[0] && (
+                <div className="w-24 h-24 relative">
+                  {isLoading ? (
+                    <picture>
+                      <img
+                        loading="lazy"
+                        alt={article.title + article.author}
+                        src={article.images[0].originSrc}
+                        className="w-full h-full bg-black object-contain rounded-full"
+                      />
+                      <source
+                        srcSet={
+                          article.images[0].smallSrc ||
+                          article.images[0].originSrc
+                        }
+                        media="(max-width: 640px)"
+                      />
+                    </picture>
+                  ) : (
+                    <SkeletonThumbnail />
+                  )}
+                  <picture>
+                    <img
+                      alt={article.title + article.author}
+                      src={article.images[0].originSrc}
+                      style={{ display: "none" }}
+                      onLoad={handleLoding}
+                    />
+                    <source
+                      srcSet={
+                        article.images[0].smallSrc ||
+                        article.images[0].originSrc
+                      }
+                      media="(max-width: 640px)"
+                    />
+                  </picture>
+                  <div className="flex flex-col items-normal justify-normal">
+                    <div className="text-theme-description leading-theme-description font-bold pt-2 text-ellipsis overflow-hidden whitespace-nowrap hidden xs:block">
+                      {article.title}
+                    </div>
+                    <div className="text-theme-tiny leading-theme-tiny text-theme-grey hidden xs:block">
+                      {article.author}
+                    </div>
+                    <div className="text-theme-tiny leading-theme-tiny text-theme-grey hidden xs:block">
+                      {article.tags}
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
-        )}
+          <div>
+            <p className="indent-0 text-theme-description leading-theme-description text-ellipsis overflow-hidden whitespace-nowrap">
+              {/**
+               * 1. 이미지 제거 - ![Image](*) 와 같은 문자열 제거
+               * 2. # 제거 - #과 함께 단어가 나오는 경우 제거
+               * 3. 줄바꿈 제거 - \n 제거
+               * 4. --- 제거
+               * 5. | 제거
+               */}
+              {article.description
+                .replace(/!\[.*?\]\(.*?\)/g, "") // 이미지 제거
+                .replace(/#+/g, "") // # 제거
+                .replace(/\n/g, " ")
+                .replace(/---/g, " ")
+                .replace(/\|/g, " ")}
+            </p>
+          </div>
+        </div>
       </a>
     </div>
   );

--- a/apps/web/src/pages/News/News.tsx
+++ b/apps/web/src/pages/News/News.tsx
@@ -55,7 +55,7 @@ const NewsPage = () => {
 
         return [
           {
-            url: firstArticle.images[0] || "",
+            url: firstArticle.images[0]?.originSrc || "",
             caption: `${data.data?.data?.year}년 - ${firstArticle.title}`,
             datePublished: firstArticle.dateTime
               ? new Date(firstArticle.dateTime).toISOString()
@@ -71,7 +71,7 @@ const NewsPage = () => {
       <MyHelmet
         title="News"
         description={metaDescription}
-        imgUrl={metaImgUrl}
+        imgUrl={metaImgUrl ? metaImgUrl.originSrc : undefined}
       />
       {structuredData && <StructuredData data={structuredData} />}
       <DefaultLayout>


### PR DESCRIPTION
## 개요
웹 앱의 뉴스 카드 스타일을 개선하고, 관리자 앱의 수상이력 삭제 로직 및 뉴스 페이지 메타데이터 처리를 수정했습니다.

## 주요 변경 사항
### 1. 웹 앱 스타일 및 기능 개선
- **NewsCard 컴포넌트 개선**: 
    - 뉴스 카드의 레이아웃을 로 변경하여 텍스트와 썸네일을 병렬로 배치했습니다.
    - 썸네일 이미지를 원형()으로 변경하고 크기를 조정했습니다.
    - 뉴스 본문()에서 마크다운 요소(이미지, #, 줄바꿈 등)를 제거하고 한 줄로 표시되도록 처리했습니다.
- **뉴스 페이지 메타데이터 수정**: 에서 이미지 URL 처리 시 객체가 아닌  문자열을 사용하도록 수정했습니다.

### 2. 관리자 앱 기능 개선
- **수상이력 삭제 로직 강화**:  호출 시 와  콜백을 명확히 처리하여 삭제 성공/실패 시 적절한 토스트 메시지를 표시하고 모달을 닫도록 개선했습니다.

## 테스트 방법
1. 웹 앱 뉴스 목록에서 카드 레이아웃 및 썸네일 스타일 확인
2. 뉴스 본문 미리보기가 깔끔하게 출력되는지 확인
3. 관리자 앱에서 수상이력 삭제 시 토스트 메시지 및 모달 닫힘 동작 확인