### PR TITLE
feat(admin): 하이라이트 영상 라벨링 페이지

### DIFF
--- a/apps/admin/src/app/app.tsx
+++ b/apps/admin/src/app/app.tsx
@@ -3,12 +3,13 @@ import DefaultLayout from "@/components/layouts/DefaultLayout";
 import SheetWrapper from "@/components/layouts/SheetWrapper";
 import { v2Admin } from "@packages/api";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export const App = () => {
   const [refreshTried, setRefreshTried] = useState(false);
 
   const navigation = useNavigate();
+  const location = useLocation();
 
   const {
     data: adminProfile,
@@ -43,13 +44,20 @@ export const App = () => {
   }, [error?.status, isLoading, navigation, refreshMutation, refreshTried]);
 
   const isAuthorized = isSuccess && adminProfile?.data;
+  const isVideoFullpage = /^\/videos\/fullpage\/\d+\/?$/.test(
+    location.pathname,
+  );
 
   return (
-    <DefaultLayout showSidebar={!!isAuthorized}>
+    <DefaultLayout showSidebar={!!isAuthorized && !isVideoFullpage}>
       {isLoading ? null : isAuthorized ? (
-        <SheetWrapper>
+        isVideoFullpage ? (
           <AuthRouter />
-        </SheetWrapper>
+        ) : (
+          <SheetWrapper>
+            <AuthRouter />
+          </SheetWrapper>
+        )
       ) : (
         <PublicRouter />
       )}

--- a/apps/admin/src/app/routers/auth-router.tsx
+++ b/apps/admin/src/app/routers/auth-router.tsx
@@ -25,6 +25,7 @@ import { RouterUrl } from "./router-url";
 
 const StaffAndAbove = ["root", "president", "manager", "staff"];
 const GeneralAndAbove = [...StaffAndAbove, "general"];
+const VideoLabelingRoles = [...GeneralAndAbove, "graduate"];
 
 const ProtectedRoute = ({
   allowedRoles,
@@ -225,11 +226,11 @@ export const AuthRouter = () => {
         }
       />
 
-      {/* 영상 라벨링 - Staff 이상 */}
+      {/* 영상 라벨링 - etc 제외 */}
       <Route
         path={RouterUrl.영상.목록}
         element={
-          <ProtectedRoute allowedRoles={StaffAndAbove}>
+          <ProtectedRoute allowedRoles={VideoLabelingRoles}>
             {WithHelmet(<VideoLabelingPage />, "하이라이트 라벨링")}
           </ProtectedRoute>
         }
@@ -237,7 +238,7 @@ export const AuthRouter = () => {
       <Route
         path={RouterUrl.영상.상세({ id: ":id" as unknown as number })}
         element={
-          <ProtectedRoute allowedRoles={StaffAndAbove}>
+          <ProtectedRoute allowedRoles={VideoLabelingRoles}>
             {WithHelmet(<VideoLabelingDetailPage />, "영상 라벨링")}
           </ProtectedRoute>
         }

--- a/apps/admin/src/app/routers/auth-router.tsx
+++ b/apps/admin/src/app/routers/auth-router.tsx
@@ -18,6 +18,7 @@ import { UserPage } from "@/pages/user";
 import { UserDetailPage } from "@/pages/user/detail";
 import { VideoLabelingPage } from "@/pages/video";
 import { VideoLabelingDetailPage } from "@/pages/video/detail";
+import { VideoLabelingFullpage } from "@/pages/video/fullpage";
 import WriteArticlePage from "@/pages/WriteArticlePage";
 import { v2Admin } from "@packages/api";
 import { Navigate, Route, Routes } from "react-router-dom";
@@ -227,6 +228,16 @@ export const AuthRouter = () => {
       />
 
       {/* 영상 라벨링 - etc 제외 */}
+      <Route
+        path={RouterUrl.영상.풀페이지({
+          jobId: ":jobId" as unknown as number,
+        })}
+        element={
+          <ProtectedRoute allowedRoles={VideoLabelingRoles}>
+            {WithHelmet(<VideoLabelingFullpage />, "하이라이트 전체화면")}
+          </ProtectedRoute>
+        }
+      />
       <Route
         path={RouterUrl.영상.목록}
         element={

--- a/apps/admin/src/app/routers/auth-router.tsx
+++ b/apps/admin/src/app/routers/auth-router.tsx
@@ -16,6 +16,8 @@ import { TrainingLogPage } from "@/pages/training-log";
 import { TrainingLogDetail } from "@/pages/training-log/training-log-detail";
 import { UserPage } from "@/pages/user";
 import { UserDetailPage } from "@/pages/user/detail";
+import { VideoLabelingPage } from "@/pages/video";
+import { VideoLabelingDetailPage } from "@/pages/video/detail";
 import WriteArticlePage from "@/pages/WriteArticlePage";
 import { v2Admin } from "@packages/api";
 import { Navigate, Route, Routes } from "react-router-dom";
@@ -219,6 +221,24 @@ export const AuthRouter = () => {
         element={
           <ProtectedRoute allowedRoles={StaffAndAbove}>
             {WithHelmet(<Awards />, "수상내역")}
+          </ProtectedRoute>
+        }
+      />
+
+      {/* 영상 라벨링 - Staff 이상 */}
+      <Route
+        path={RouterUrl.영상.목록}
+        element={
+          <ProtectedRoute allowedRoles={StaffAndAbove}>
+            {WithHelmet(<VideoLabelingPage />, "하이라이트 라벨링")}
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path={RouterUrl.영상.상세({ id: ":id" as unknown as number })}
+        element={
+          <ProtectedRoute allowedRoles={StaffAndAbove}>
+            {WithHelmet(<VideoLabelingDetailPage />, "영상 라벨링")}
           </ProtectedRoute>
         }
       />

--- a/apps/admin/src/app/routers/router-url.ts
+++ b/apps/admin/src/app/routers/router-url.ts
@@ -16,6 +16,10 @@ export const RouterUrl = {
     작성: "/notice/write",
   },
   수상내역: "/awards",
+  영상: {
+    목록: "/videos",
+    상세: ({ id }: { id: number }) => `/videos/${id}`,
+  },
   훈련일지: {
     목록: "/training",
     상세: ({ id }: { id: number }) => `/training/${id}`,
@@ -40,6 +44,7 @@ export const RouteLabels: Record<string, string> = {
   notice: "공지",
   gallery: "갤러리",
   awards: "수상내역",
+  videos: "영상 라벨링",
   write: "작성",
   users: "회원",
   mypage: "마이페이지",

--- a/apps/admin/src/app/routers/router-url.ts
+++ b/apps/admin/src/app/routers/router-url.ts
@@ -19,6 +19,7 @@ export const RouterUrl = {
   영상: {
     목록: "/videos",
     상세: ({ id }: { id: number }) => `/videos/${id}`,
+    풀페이지: ({ jobId }: { jobId: number }) => `/videos/fullpage/${jobId}`,
   },
   훈련일지: {
     목록: "/training",
@@ -45,6 +46,7 @@ export const RouteLabels: Record<string, string> = {
   gallery: "갤러리",
   awards: "수상내역",
   videos: "영상 라벨링",
+  fullpage: "하이라이트 전체화면",
   write: "작성",
   users: "회원",
   mypage: "마이페이지",

--- a/apps/admin/src/components/admin/Main/LNB.tsx
+++ b/apps/admin/src/components/admin/Main/LNB.tsx
@@ -19,6 +19,7 @@ import { match, P } from "ts-pattern";
 
 const StaffAndAbove = ["root", "president", "manager", "staff"];
 const GeneralAndAbove = [...StaffAndAbove, "general"];
+const VideoLabelingRoles = [...GeneralAndAbove, "graduate"];
 
 const menuItems = [
   { icon: Home, label: "홈", path: RouterUrl.홈 },
@@ -56,7 +57,7 @@ const menuItems = [
     icon: Film,
     label: "영상 라벨링",
     path: RouterUrl.영상.목록,
-    allowedRoles: StaffAndAbove,
+    allowedRoles: VideoLabelingRoles,
   },
 ];
 

--- a/apps/admin/src/components/admin/Main/LNB.tsx
+++ b/apps/admin/src/components/admin/Main/LNB.tsx
@@ -8,6 +8,7 @@ import {
   Home,
   LogOut,
   Menu,
+  Film,
   Newspaper,
   Trophy,
   Users,
@@ -49,6 +50,12 @@ const menuItems = [
     icon: Trophy,
     label: "수상내역",
     path: RouterUrl.수상내역,
+    allowedRoles: StaffAndAbove,
+  },
+  {
+    icon: Film,
+    label: "영상 라벨링",
+    path: RouterUrl.영상.목록,
     allowedRoles: StaffAndAbove,
   },
 ];

--- a/apps/admin/src/features/video/api.ts
+++ b/apps/admin/src/features/video/api.ts
@@ -1,16 +1,11 @@
-import axios from "axios";
-
 /**
- * 영상 라벨링 엔드포인트는 아직 swagger(orval) 생성 대상이 아니라서
- * admin 스코프(`/api/v2/admin`)로 직접 axios 호출한다.
- * baseURL 은 생성된 @packages/api 클라이언트와 동일 출처를 사용한다.
+ * 영상 라벨링 화면에서 쓰는 도메인 타입.
+ *
+ * orval 생성 모델(@packages/api 의 GetApiV2AdminVideos... 류)과 형태가 동일하지만,
+ * 해당 모델 타입은 v2Admin 네임스페이스로 재노출되지 않아 직접 import 할 수 없다.
+ * 따라서 컴포넌트 prop 타입은 여기서 명시적으로 유지한다.
+ * 실제 데이터 패칭/라벨 저장은 `./hooks` 의 생성 훅을 사용한다.
  */
-const baseURL = `${import.meta.env.VITE_API_BASE_URL}/v2/admin`;
-
-export const videoApi = axios.create({
-  baseURL,
-  withCredentials: true,
-});
 
 export type VideoJobStatus = "uploaded" | "processing" | "done" | "failed";
 export type TechniqueResult = "NONE" | "ATTEMPT" | "SUCCESS";
@@ -51,21 +46,6 @@ export interface VideoJobListItem {
   updatedAt: string;
 }
 
-export interface VideoJobDetail {
-  id: number;
-  originalFilename: string;
-  originalPath: string;
-  originalVideoUrl: string;
-  eventsJsonPath: string;
-  eventsJsonUrl: string;
-  status: VideoJobStatus;
-  durationSec: number | null;
-  errorMessage: string | null;
-  createdAt: string;
-  updatedAt: string;
-  highlights: VideoHighlight[];
-}
-
 export interface CreateVideoLabelBody {
   techniqueResult: TechniqueResult;
   score?: Score | null;
@@ -74,28 +54,3 @@ export interface CreateVideoLabelBody {
   correctedEventSec?: number | null;
   memo?: string | null;
 }
-
-export const getVideoJobs = async (): Promise<VideoJobListItem[]> => {
-  const { data } = await videoApi.get<{ jobs: VideoJobListItem[] }>("/videos");
-  return data.jobs;
-};
-
-export const getVideoJobDetail = async (
-  jobId: number,
-): Promise<VideoJobDetail> => {
-  const { data } = await videoApi.get<{ job: VideoJobDetail }>(
-    `/videos/${jobId}`,
-  );
-  return data.job;
-};
-
-export const createHighlightLabel = async (
-  highlightId: number,
-  body: CreateVideoLabelBody,
-): Promise<{ labelId: number }> => {
-  const { data } = await videoApi.post<{ labelId: number }>(
-    `/highlights/${highlightId}/label`,
-    body,
-  );
-  return data;
-};

--- a/apps/admin/src/features/video/api.ts
+++ b/apps/admin/src/features/video/api.ts
@@ -1,0 +1,101 @@
+import axios from "axios";
+
+/**
+ * 영상 라벨링 엔드포인트는 아직 swagger(orval) 생성 대상이 아니라서
+ * admin 스코프(`/api/v2/admin`)로 직접 axios 호출한다.
+ * baseURL 은 생성된 @packages/api 클라이언트와 동일 출처를 사용한다.
+ */
+const baseURL = `${import.meta.env.VITE_API_BASE_URL}/v2/admin`;
+
+export const videoApi = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+export type VideoJobStatus = "uploaded" | "processing" | "done" | "failed";
+export type TechniqueResult = "NONE" | "ATTEMPT" | "SUCCESS";
+export type Score = "NONE" | "YUKO" | "WAZA_ARI" | "IPPON";
+
+export interface LatestVideoLabel {
+  id: number;
+  techniqueResult: TechniqueResult;
+  score: Score | null;
+  technique: string | null;
+  highlightScore: number | null;
+  correctedEventSec: number | null;
+  memo: string | null;
+  createdAt: string;
+}
+
+export interface VideoHighlight {
+  id: number;
+  jobId: number;
+  eventSec: number;
+  startSec: number;
+  endSec: number;
+  confidence: number;
+  clipPath: string;
+  clipUrl: string;
+  createdAt: string;
+  latestLabel: LatestVideoLabel | null;
+}
+
+export interface VideoJobListItem {
+  id: number;
+  originalFilename: string;
+  status: VideoJobStatus;
+  durationSec: number | null;
+  errorMessage: string | null;
+  highlightCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VideoJobDetail {
+  id: number;
+  originalFilename: string;
+  originalPath: string;
+  originalVideoUrl: string;
+  eventsJsonPath: string;
+  eventsJsonUrl: string;
+  status: VideoJobStatus;
+  durationSec: number | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  highlights: VideoHighlight[];
+}
+
+export interface CreateVideoLabelBody {
+  techniqueResult: TechniqueResult;
+  score?: Score | null;
+  technique?: string | null;
+  highlightScore?: number | null;
+  correctedEventSec?: number | null;
+  memo?: string | null;
+}
+
+export const getVideoJobs = async (): Promise<VideoJobListItem[]> => {
+  const { data } = await videoApi.get<{ jobs: VideoJobListItem[] }>("/videos");
+  return data.jobs;
+};
+
+export const getVideoJobDetail = async (
+  jobId: number,
+): Promise<VideoJobDetail> => {
+  const { data } = await videoApi.get<{ job: VideoJobDetail }>(
+    `/videos/${jobId}`,
+  );
+  return data.job;
+};
+
+export const createHighlightLabel = async (
+  highlightId: number,
+  body: CreateVideoLabelBody,
+): Promise<{ labelId: number }> => {
+  const { data } = await videoApi.post<{ labelId: number }>(
+    `/highlights/${highlightId}/label`,
+    body,
+  );
+  return data;
+};

--- a/apps/admin/src/features/video/api.ts
+++ b/apps/admin/src/features/video/api.ts
@@ -9,8 +9,11 @@ import { v2AdminModel } from "@packages/api/model";
 export type VideoJobStatus = v2AdminModel.GetApiV2AdminVideos200JobsItemStatus;
 export type VideoJobListItem = v2AdminModel.GetApiV2AdminVideos200JobsItem;
 export type VideoJobDetail = v2AdminModel.GetApiV2AdminVideosJobId200Job;
+export type VideoEvent =
+  v2AdminModel.GetApiV2AdminVideosJobIdEvents200EventsItem;
 export type VideoHighlight =
-  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItem;
+  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItem &
+    Pick<VideoEvent, "isLabeledByCurrentUser">;
 export type LatestVideoLabel =
   v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItemLatestLabel;
 

--- a/apps/admin/src/features/video/api.ts
+++ b/apps/admin/src/features/video/api.ts
@@ -1,56 +1,21 @@
+import { v2AdminModel } from "@packages/api/model";
+
 /**
  * 영상 라벨링 화면에서 쓰는 도메인 타입.
- *
- * orval 생성 모델(@packages/api 의 GetApiV2AdminVideos... 류)과 형태가 동일하지만,
- * 해당 모델 타입은 v2Admin 네임스페이스로 재노출되지 않아 직접 import 할 수 없다.
- * 따라서 컴포넌트 prop 타입은 여기서 명시적으로 유지한다.
+ * orval 로 생성된 모델(@packages/api/model)을 그대로 별칭으로 재노출한다.
  * 실제 데이터 패칭/라벨 저장은 `./hooks` 의 생성 훅을 사용한다.
  */
 
-export type VideoJobStatus = "uploaded" | "processing" | "done" | "failed";
-export type TechniqueResult = "NONE" | "ATTEMPT" | "SUCCESS";
-export type Score = "NONE" | "YUKO" | "WAZA_ARI" | "IPPON";
+export type VideoJobStatus = v2AdminModel.GetApiV2AdminVideos200JobsItemStatus;
+export type VideoJobListItem = v2AdminModel.GetApiV2AdminVideos200JobsItem;
+export type VideoJobDetail = v2AdminModel.GetApiV2AdminVideosJobId200Job;
+export type VideoHighlight =
+  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItem;
+export type LatestVideoLabel =
+  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItemLatestLabel;
 
-export interface LatestVideoLabel {
-  id: number;
-  techniqueResult: TechniqueResult;
-  score: Score | null;
-  technique: string | null;
-  highlightScore: number | null;
-  correctedEventSec: number | null;
-  memo: string | null;
-  createdAt: string;
-}
-
-export interface VideoHighlight {
-  id: number;
-  jobId: number;
-  eventSec: number;
-  startSec: number;
-  endSec: number;
-  confidence: number;
-  clipPath: string;
-  clipUrl: string;
-  createdAt: string;
-  latestLabel: LatestVideoLabel | null;
-}
-
-export interface VideoJobListItem {
-  id: number;
-  originalFilename: string;
-  status: VideoJobStatus;
-  durationSec: number | null;
-  errorMessage: string | null;
-  highlightCount: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface CreateVideoLabelBody {
-  techniqueResult: TechniqueResult;
-  score?: Score | null;
-  technique?: string | null;
-  highlightScore?: number | null;
-  correctedEventSec?: number | null;
-  memo?: string | null;
-}
+export type CreateVideoLabelBody =
+  v2AdminModel.PostApiV2AdminHighlightsHighlightIdLabelBody;
+export type TechniqueResult =
+  v2AdminModel.PostApiV2AdminHighlightsHighlightIdLabelBodyTechniqueResult;
+export type Score = NonNullable<CreateVideoLabelBody["score"]>;

--- a/apps/admin/src/features/video/hooks.ts
+++ b/apps/admin/src/features/video/hooks.ts
@@ -1,0 +1,51 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  createHighlightLabel,
+  getVideoJobDetail,
+  getVideoJobs,
+  type CreateVideoLabelBody,
+} from "./api";
+
+export const videoKeys = {
+  all: ["admin", "videos"] as const,
+  list: () => [...videoKeys.all, "list"] as const,
+  detail: (jobId: number) => [...videoKeys.all, "detail", jobId] as const,
+};
+
+export const useVideoJobs = () => {
+  return useQuery({
+    queryKey: videoKeys.list(),
+    queryFn: getVideoJobs,
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useVideoJobDetail = (jobId: number) => {
+  return useQuery({
+    queryKey: videoKeys.detail(jobId),
+    queryFn: () => getVideoJobDetail(jobId),
+    enabled: Number.isFinite(jobId) && jobId > 0,
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useCreateHighlightLabel = (jobId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      highlightId,
+      body,
+    }: {
+      highlightId: number;
+      body: CreateVideoLabelBody;
+    }) => createHighlightLabel(highlightId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: videoKeys.detail(jobId) });
+    },
+  });
+};

--- a/apps/admin/src/features/video/hooks.ts
+++ b/apps/admin/src/features/video/hooks.ts
@@ -1,51 +1,40 @@
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import {
-  createHighlightLabel,
-  getVideoJobDetail,
-  getVideoJobs,
-  type CreateVideoLabelBody,
-} from "./api";
+import { v2Admin } from "@packages/api";
+import { useQueryClient } from "@tanstack/react-query";
 
-export const videoKeys = {
-  all: ["admin", "videos"] as const,
-  list: () => [...videoKeys.all, "list"] as const,
-  detail: (jobId: number) => [...videoKeys.all, "detail", jobId] as const,
-};
-
-export const useVideoJobs = () => {
-  return useQuery({
-    queryKey: videoKeys.list(),
-    queryFn: getVideoJobs,
-    staleTime: 30 * 1000,
+/**
+ * 영상 라벨링 데이터는 orval 로 생성된 @packages/api 의 admin 훅을 그대로 사용한다.
+ * (업로드/clip 등 file multipart 엔드포인트의 생성 타입은 깨져 있으나, 여기서 쓰는
+ *  목록/상세 조회와 라벨 저장은 정상 동작한다.)
+ */
+export const useVideoJobs = () =>
+  v2Admin.useGetApiV2AdminVideos({
+    axios: { withCredentials: true },
+    query: {
+      select: (res) => res.data.jobs,
+      staleTime: 30 * 1000,
+    },
   });
-};
 
-export const useVideoJobDetail = (jobId: number) => {
-  return useQuery({
-    queryKey: videoKeys.detail(jobId),
-    queryFn: () => getVideoJobDetail(jobId),
-    enabled: Number.isFinite(jobId) && jobId > 0,
-    staleTime: 30 * 1000,
+export const useVideoJobDetail = (jobId: number) =>
+  v2Admin.useGetApiV2AdminVideosJobId(jobId, {
+    axios: { withCredentials: true },
+    query: {
+      enabled: Number.isFinite(jobId) && jobId > 0,
+      select: (res) => res.data.job,
+      staleTime: 30 * 1000,
+    },
   });
-};
 
 export const useCreateHighlightLabel = (jobId: number) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: ({
-      highlightId,
-      body,
-    }: {
-      highlightId: number;
-      body: CreateVideoLabelBody;
-    }) => createHighlightLabel(highlightId, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: videoKeys.detail(jobId) });
+  return v2Admin.usePostApiV2AdminHighlightsHighlightIdLabel({
+    axios: { withCredentials: true },
+    mutation: {
+      onSuccess: () =>
+        queryClient.invalidateQueries({
+          queryKey: v2Admin.getGetApiV2AdminVideosJobIdQueryKey(jobId),
+        }),
     },
   });
 };

--- a/apps/admin/src/features/video/hooks.ts
+++ b/apps/admin/src/features/video/hooks.ts
@@ -25,16 +25,32 @@ export const useVideoJobDetail = (jobId: number) =>
     },
   });
 
+export const useVideoEvents = (jobId: number) =>
+  v2Admin.useGetApiV2AdminVideosJobIdEvents(jobId, {
+    axios: { withCredentials: true },
+    query: {
+      enabled: Number.isFinite(jobId) && jobId > 0,
+      select: (res) => res.data.events,
+      staleTime: 30 * 1000,
+    },
+  });
+
 export const useCreateHighlightLabel = (jobId: number) => {
   const queryClient = useQueryClient();
 
   return v2Admin.usePostApiV2AdminHighlightsHighlightIdLabel({
     axios: { withCredentials: true },
     mutation: {
-      onSuccess: () =>
-        queryClient.invalidateQueries({
-          queryKey: v2Admin.getGetApiV2AdminVideosJobIdQueryKey(jobId),
-        }),
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: v2Admin.getGetApiV2AdminVideosJobIdEventsQueryKey(jobId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: v2Admin.getGetApiV2AdminVideosJobIdQueryKey(jobId),
+          }),
+        ]);
+      },
     },
   });
 };

--- a/apps/admin/src/features/video/techniques.ts
+++ b/apps/admin/src/features/video/techniques.ts
@@ -1,0 +1,130 @@
+interface TechniqueOption {
+  value: string;
+  label: string;
+}
+
+interface TechniqueGroup {
+  label: string;
+  options: TechniqueOption[];
+}
+
+export const TECHNIQUE_GROUPS: TechniqueGroup[] = [
+  {
+    label: "손기술 (Te-waza)",
+    options: [
+      { value: "업어치기", label: "업어치기 (Seoi-nage)" },
+      { value: "한팔업어치기", label: "한팔업어치기 (Ippon-seoi-nage)" },
+      { value: "빗당겨치기", label: "빗당겨치기 (Tai-otoshi)" },
+      { value: "어깨로 메치기", label: "어깨로 메치기 (Kata-guruma)" },
+      { value: "다리들어메치기", label: "다리들어메치기 (Sukui-nage)" },
+      { value: "띄어치기", label: "띄어치기 (Uki-otoshi)" },
+      { value: "모로떨어뜨리기", label: "모로떨어뜨리기 (Sumi-otoshi)" },
+      { value: "띠잡아떨어뜨리기", label: "띠잡아떨어뜨리기 (Obi-otoshi)" },
+      { value: "업어떨어뜨리기", label: "업어떨어뜨리기 (Seoi-otoshi)" },
+      { value: "외깃잡아떨어뜨리기", label: "외깃잡아떨어뜨리기" },
+      { value: "다리잡아메치기", label: "다리잡아메치기 (Morote-gari)" },
+      { value: "오금잡아메치기", label: "오금잡아메치기 (Kuchiki-taoshi)" },
+      { value: "발목잡아메치기", label: "발목잡아메치기 (Kibisu-gaeshi)" },
+      {
+        value: "허벅다리비껴되치기",
+        label: "허벅다리비껴되치기 (Uchi-mata-sukashi)",
+      },
+      { value: "안뒤축되치기", label: "안뒤축되치기 (Kouchi-gaeshi)" },
+      { value: "띠잡아뒤집기", label: "띠잡아뒤집기 (Obitori-gaeshi)" },
+    ],
+  },
+  {
+    label: "허리기술 (Koshi-waza)",
+    options: [
+      { value: "허리띄기", label: "허리띄기 (Uki-goshi)" },
+      { value: "허리껴치기", label: "허리껴치기 (O-goshi)" },
+      { value: "허리돌리기", label: "허리돌리기 (Koshi-guruma)" },
+      { value: "허리채기", label: "허리채기 (Tsurikomi-goshi)" },
+      { value: "허리후리기", label: "허리후리기 (Harai-goshi)" },
+      { value: "띠잡아허리채기", label: "띠잡아허리채기 (Tsuri-goshi)" },
+      { value: "허리튀기", label: "허리튀기 (Hane-goshi)" },
+      { value: "허리옮겨치기", label: "허리옮겨치기 (Utsuri-goshi)" },
+      { value: "뒤허리안아메치기", label: "뒤허리안아메치기 (Ushiro-goshi)" },
+      {
+        value: "소매들어 허리채기",
+        label: "소매들어 허리채기 (Sode-tsurikomi-goshi)",
+      },
+    ],
+  },
+  {
+    label: "발기술 (Ashi-waza)",
+    options: [
+      { value: "나오는발차기", label: "나오는발차기 (De-ashi-barai)" },
+      { value: "무릎대돌리기", label: "무릎대돌리기 (Hiza-guruma)" },
+      { value: "발목받치기", label: "발목받치기 (Sasae-tsurikomi-ashi)" },
+      { value: "밭다리후리기", label: "밭다리후리기 (Osoto-gari)" },
+      { value: "안다리후리기", label: "안다리후리기 (Ouchi-gari)" },
+      { value: "발뒤축후리기", label: "발뒤축후리기 (Kosoto-gari)" },
+      { value: "안뒤축후리기", label: "안뒤축후리기 (Kouchi-gari)" },
+      { value: "모두걸기", label: "모두걸기 (Okuri-ashi-barai)" },
+      { value: "허벅다리걸기", label: "허벅다리걸기" },
+      { value: "발뒤축걸기", label: "발뒤축걸기" },
+      { value: "다리대돌리기", label: "다리대돌리기 (Ashi-guruma)" },
+      { value: "발목후리기", label: "발목후리기 (Harai-tsurikomi-ashi)" },
+      { value: "허리대돌리기", label: "허리대돌리기 (O-guruma)" },
+      { value: "두밭다리걸기", label: "두밭다리걸기 (Osoto-guruma)" },
+      { value: "밭다리걸기", label: "밭다리걸기 (Osoto-otoshi)" },
+      { value: "모두걸기되치기", label: "모두걸기되치기 (Tsubame-gaeshi)" },
+      { value: "밭다리되치기", label: "밭다리되치기 (Osoto-gaeshi)" },
+      { value: "안다리되치기", label: "안다리되치기 (Ouchi-gaeshi)" },
+      { value: "허리튀기되치기", label: "허리튀기되치기 (Hane-goshi-gaeshi)" },
+      {
+        value: "허리후리기되치기",
+        label: "허리후리기되치기 (Harai-goshi-gaeshi)",
+      },
+      { value: "허벅다리되치기", label: "허벅다리되치기 (Uchi-mata-gaeshi)" },
+    ],
+  },
+  {
+    label: "바로 누우면서 메치기 (Ma-sutemi-waza)",
+    options: [
+      { value: "배대뒤치기", label: "배대뒤치기 (Tomoe-nage)" },
+      { value: "안오금띄기", label: "안오금띄기 (Sumi-gaeshi)" },
+      { value: "누우면서던지기", label: "누우면서던지기 (Ura-nage)" },
+      {
+        value: "끌어누우며던지기",
+        label: "끌어누우며던지기 (Hikikomi-gaeshi)",
+      },
+      { value: "뒤집어넘기기", label: "뒤집어넘기기 (Tawara-gaeshi)" },
+    ],
+  },
+  {
+    label: "모로 누우면서 메치기 (Yoko-sutemi-waza)",
+    options: [
+      { value: "옆으로 떨어뜨리기", label: "옆으로 떨어뜨리기 (Yoko-otoshi)" },
+      { value: "모로띄기", label: "모로띄기 (Uki-waza)" },
+      { value: "오금대떨어뜨리기", label: "오금대떨어뜨리기 (Tani-otoshi)" },
+      {
+        value: "옆으로누우며던지기",
+        label: "옆으로누우며던지기 (Yoko-wakare)",
+      },
+      { value: "모로걸기", label: "모로걸기 (Yoko-gake)" },
+      { value: "모로돌리기", label: "모로돌리기 (Yoko-guruma)" },
+      { value: "허리안아돌리기", label: "허리안아돌리기 (Daki-wakare)" },
+      {
+        value: "허벅다리감아치기",
+        label: "허벅다리감아치기 (Uchi-mata-makikomi)",
+      },
+      { value: "밭다리감아치기", label: "밭다리감아치기 (Osoto-makikomi)" },
+      { value: "안쪽감아치기", label: "안쪽감아치기 (Uchi-makikomi)" },
+      { value: "바깥감아치기", label: "바깥감아치기 (Soto-makikomi)" },
+      {
+        value: "허리후리기감아치기",
+        label: "허리후리기감아치기 (Harai-makikomi)",
+      },
+      { value: "허리튀겨감아치기", label: "허리튀겨감아치기 (Hane-makikomi)" },
+      { value: "안뒤축감아치기", label: "안뒤축감아치기 (Kouchi-makikomi)" },
+    ],
+  },
+];
+
+export const TECHNIQUE_VALUES = new Set(
+  TECHNIQUE_GROUPS.flatMap((group) =>
+    group.options.map((option) => option.value),
+  ),
+);

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -2,8 +2,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/shared/lib/utils";
-import { useMemo, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { z } from "zod";
 import {
   type CreateVideoLabelBody,
   type Score,
@@ -25,7 +27,32 @@ const SCORES: { value: Score; label: string }[] = [
   { value: "IPPON", label: "한판" },
 ];
 
+const labelFormSchema = z.object({
+  techniqueResult: z.enum(["NONE", "ATTEMPT", "SUCCESS"]),
+  score: z.enum(["NONE", "YUKO", "WAZA_ARI", "IPPON"]),
+  technique: z.string().max(100, "기술명은 100자 이하여야 합니다."),
+  highlightScore: z
+    .string()
+    .refine(
+      (v) =>
+        v.trim() === "" ||
+        (/^\d+$/.test(v.trim()) && Number(v) >= 0 && Number(v) <= 10),
+      "0~10 사이 정수여야 합니다.",
+    ),
+  correctedEventSec: z
+    .string()
+    .refine(
+      (v) => v.trim() === "" || !Number.isNaN(Number(v)),
+      "숫자를 입력해주세요.",
+    ),
+  memo: z.string().max(1000, "메모는 1000자 이하여야 합니다."),
+});
+
+type LabelFormValues = z.infer<typeof labelFormSchema>;
+
 const formatSec = (sec: number) => `${sec.toFixed(1)}초`;
+
+const toNullable = (value: string) => (value.trim() === "" ? null : value.trim());
 
 interface Props {
   index: number;
@@ -36,49 +63,44 @@ interface Props {
 export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
   const label = highlight.latestLabel;
 
-  const [techniqueResult, setTechniqueResult] = useState<TechniqueResult>(
-    label?.techniqueResult ?? "NONE",
-  );
-  const [score, setScore] = useState<Score>(label?.score ?? "NONE");
-  const [technique, setTechnique] = useState(label?.technique ?? "");
-  const [highlightScore, setHighlightScore] = useState(
-    label?.highlightScore != null ? String(label.highlightScore) : "",
-  );
-  const [correctedEventSec, setCorrectedEventSec] = useState(
-    label?.correctedEventSec != null ? String(label.correctedEventSec) : "",
-  );
-  const [memo, setMemo] = useState(label?.memo ?? "");
-
   const mutation = useCreateHighlightLabel(jobId);
 
-  const highlightScoreError = useMemo(() => {
-    if (highlightScore.trim() === "") return null;
-    const n = Number(highlightScore);
-    if (!Number.isInteger(n) || n < 0 || n > 10) {
-      return "0~10 사이 정수여야 합니다.";
-    }
-    return null;
-  }, [highlightScore]);
-
-  const handleSubmit = () => {
-    if (highlightScoreError) {
-      toast.error(highlightScoreError);
-      return;
-    }
-    if (memo.length > 1000) {
-      toast.error("메모는 1000자 이하여야 합니다.");
-      return;
-    }
-
-    const body: CreateVideoLabelBody = {
-      techniqueResult,
-      score: score === "NONE" ? "NONE" : score,
-      technique: technique.trim() === "" ? null : technique.trim(),
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<LabelFormValues>({
+    resolver: zodResolver(labelFormSchema),
+    defaultValues: {
+      techniqueResult: label?.techniqueResult ?? "NONE",
+      score: label?.score ?? "NONE",
+      technique: label?.technique ?? "",
       highlightScore:
-        highlightScore.trim() === "" ? null : Number(highlightScore),
+        label?.highlightScore != null ? String(label.highlightScore) : "",
       correctedEventSec:
-        correctedEventSec.trim() === "" ? null : Number(correctedEventSec),
-      memo: memo.trim() === "" ? null : memo.trim(),
+        label?.correctedEventSec != null ? String(label.correctedEventSec) : "",
+      memo: label?.memo ?? "",
+    },
+  });
+
+  const memoLength = watch("memo").length;
+
+  const onSubmit = (values: LabelFormValues) => {
+    const body: CreateVideoLabelBody = {
+      techniqueResult: values.techniqueResult,
+      score: values.score,
+      technique: toNullable(values.technique),
+      highlightScore:
+        values.highlightScore.trim() === ""
+          ? null
+          : Number(values.highlightScore),
+      correctedEventSec:
+        values.correctedEventSec.trim() === ""
+          ? null
+          : Number(values.correctedEventSec),
+      memo: toNullable(values.memo),
     };
 
     mutation.mutate(
@@ -131,79 +153,95 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
         </dl>
       </div>
 
-      <div className="flex flex-col gap-3 md:w-1/2">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col gap-3 md:w-1/2"
+      >
         <Field label="기술 결과" required>
-          <SegmentedControl
-            options={TECHNIQUE_RESULTS}
-            value={techniqueResult}
-            onChange={setTechniqueResult}
+          <Controller
+            control={control}
+            name="techniqueResult"
+            render={({ field }) => (
+              <SegmentedControl
+                options={TECHNIQUE_RESULTS}
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
           />
         </Field>
 
         <Field label="점수">
-          <SegmentedControl
-            options={SCORES}
-            value={score}
-            onChange={setScore}
+          <Controller
+            control={control}
+            name="score"
+            render={({ field }) => (
+              <SegmentedControl
+                options={SCORES}
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
           />
         </Field>
 
-        <Field label="기술명">
+        <Field label="기술명" error={errors.technique?.message}>
           <Input
-            value={technique}
+            {...register("technique")}
             maxLength={100}
             placeholder="예) 업어치기"
-            onChange={(e) => setTechnique(e.target.value)}
+            aria-invalid={!!errors.technique}
           />
         </Field>
 
         <div className="grid grid-cols-2 gap-3">
-          <Field label="하이라이트 점수 (0~10)">
+          <Field
+            label="하이라이트 점수 (0~10)"
+            error={errors.highlightScore?.message}
+          >
             <Input
+              {...register("highlightScore")}
               type="number"
               min={0}
               max={10}
               step={1}
-              value={highlightScore}
-              aria-invalid={!!highlightScoreError}
               placeholder="0~10"
-              onChange={(e) => setHighlightScore(e.target.value)}
+              aria-invalid={!!errors.highlightScore}
             />
-            {highlightScoreError && (
-              <p className="mt-1 text-xs text-red-600">{highlightScoreError}</p>
-            )}
           </Field>
 
-          <Field label="보정 이벤트 시각(초)">
+          <Field
+            label="보정 이벤트 시각(초)"
+            error={errors.correctedEventSec?.message}
+          >
             <Input
+              {...register("correctedEventSec")}
               type="number"
               step="0.1"
-              value={correctedEventSec}
               placeholder={highlight.eventSec.toFixed(1)}
-              onChange={(e) => setCorrectedEventSec(e.target.value)}
+              aria-invalid={!!errors.correctedEventSec}
             />
           </Field>
         </div>
 
-        <Field label={`메모 (${memo.length}/1000)`}>
+        <Field label={`메모 (${memoLength}/1000)`} error={errors.memo?.message}>
           <Textarea
-            value={memo}
+            {...register("memo")}
             maxLength={1000}
             rows={3}
             placeholder="특이사항을 적어주세요."
-            onChange={(e) => setMemo(e.target.value)}
+            aria-invalid={!!errors.memo}
           />
         </Field>
 
         <Button
-          type="button"
-          onClick={handleSubmit}
+          type="submit"
           disabled={mutation.isPending}
           className="mt-1 self-end"
         >
           {mutation.isPending ? "저장 중..." : "라벨 저장"}
         </Button>
-      </div>
+      </form>
     </div>
   );
 };
@@ -211,10 +249,12 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
 const Field = ({
   label,
   required,
+  error,
   children,
 }: {
   label: string;
   required?: boolean;
+  error?: string;
   children: React.ReactNode;
 }) => (
   <label className="flex flex-col gap-1">
@@ -223,6 +263,7 @@ const Field = ({
       {required && <span className="ml-0.5 text-red-500">*</span>}
     </span>
     {children}
+    {error && <p className="text-xs text-red-600">{error}</p>}
   </label>
 );
 

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -82,7 +82,7 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
     };
 
     mutation.mutate(
-      { highlightId: highlight.id, body },
+      { highlightId: highlight.id, data: body },
       {
         onSuccess: () => toast.success("라벨을 저장했어요."),
         onError: () => toast.error("라벨 저장에 실패했어요."),

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -1,0 +1,257 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/shared/lib/utils";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  type CreateVideoLabelBody,
+  type Score,
+  type TechniqueResult,
+  type VideoHighlight,
+} from "../api";
+import { useCreateHighlightLabel } from "../hooks";
+
+const TECHNIQUE_RESULTS: { value: TechniqueResult; label: string }[] = [
+  { value: "NONE", label: "없음" },
+  { value: "ATTEMPT", label: "시도" },
+  { value: "SUCCESS", label: "성공" },
+];
+
+const SCORES: { value: Score; label: string }[] = [
+  { value: "NONE", label: "없음" },
+  { value: "YUKO", label: "유효" },
+  { value: "WAZA_ARI", label: "절반" },
+  { value: "IPPON", label: "한판" },
+];
+
+const formatSec = (sec: number) => `${sec.toFixed(1)}초`;
+
+interface Props {
+  index: number;
+  highlight: VideoHighlight;
+  jobId: number;
+}
+
+export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
+  const label = highlight.latestLabel;
+
+  const [techniqueResult, setTechniqueResult] = useState<TechniqueResult>(
+    label?.techniqueResult ?? "NONE",
+  );
+  const [score, setScore] = useState<Score>(label?.score ?? "NONE");
+  const [technique, setTechnique] = useState(label?.technique ?? "");
+  const [highlightScore, setHighlightScore] = useState(
+    label?.highlightScore != null ? String(label.highlightScore) : "",
+  );
+  const [correctedEventSec, setCorrectedEventSec] = useState(
+    label?.correctedEventSec != null ? String(label.correctedEventSec) : "",
+  );
+  const [memo, setMemo] = useState(label?.memo ?? "");
+
+  const mutation = useCreateHighlightLabel(jobId);
+
+  const highlightScoreError = useMemo(() => {
+    if (highlightScore.trim() === "") return null;
+    const n = Number(highlightScore);
+    if (!Number.isInteger(n) || n < 0 || n > 10) {
+      return "0~10 사이 정수여야 합니다.";
+    }
+    return null;
+  }, [highlightScore]);
+
+  const handleSubmit = () => {
+    if (highlightScoreError) {
+      toast.error(highlightScoreError);
+      return;
+    }
+    if (memo.length > 1000) {
+      toast.error("메모는 1000자 이하여야 합니다.");
+      return;
+    }
+
+    const body: CreateVideoLabelBody = {
+      techniqueResult,
+      score: score === "NONE" ? "NONE" : score,
+      technique: technique.trim() === "" ? null : technique.trim(),
+      highlightScore:
+        highlightScore.trim() === "" ? null : Number(highlightScore),
+      correctedEventSec:
+        correctedEventSec.trim() === "" ? null : Number(correctedEventSec),
+      memo: memo.trim() === "" ? null : memo.trim(),
+    };
+
+    mutation.mutate(
+      { highlightId: highlight.id, body },
+      {
+        onSuccess: () => toast.success("라벨을 저장했어요."),
+        onError: () => toast.error("라벨 저장에 실패했어요."),
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border bg-white p-4 shadow-sm md:flex-row">
+      <div className="md:w-1/2">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-semibold text-neutral-800">
+            #{index + 1}
+          </span>
+          {label && (
+            <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+              라벨 있음
+            </span>
+          )}
+        </div>
+        <video
+          src={highlight.clipUrl}
+          controls
+          preload="metadata"
+          className="aspect-video w-full rounded-lg bg-black"
+        />
+        <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-neutral-500">
+          <div className="flex justify-between">
+            <dt>이벤트</dt>
+            <dd className="font-medium text-neutral-700">
+              {formatSec(highlight.eventSec)}
+            </dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>구간</dt>
+            <dd className="font-medium text-neutral-700">
+              {formatSec(highlight.startSec)} ~ {formatSec(highlight.endSec)}
+            </dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>신뢰도</dt>
+            <dd className="font-medium text-neutral-700">
+              {(highlight.confidence * 100).toFixed(0)}%
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="flex flex-col gap-3 md:w-1/2">
+        <Field label="기술 결과" required>
+          <SegmentedControl
+            options={TECHNIQUE_RESULTS}
+            value={techniqueResult}
+            onChange={setTechniqueResult}
+          />
+        </Field>
+
+        <Field label="점수">
+          <SegmentedControl
+            options={SCORES}
+            value={score}
+            onChange={setScore}
+          />
+        </Field>
+
+        <Field label="기술명">
+          <Input
+            value={technique}
+            maxLength={100}
+            placeholder="예) 업어치기"
+            onChange={(e) => setTechnique(e.target.value)}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="하이라이트 점수 (0~10)">
+            <Input
+              type="number"
+              min={0}
+              max={10}
+              step={1}
+              value={highlightScore}
+              aria-invalid={!!highlightScoreError}
+              placeholder="0~10"
+              onChange={(e) => setHighlightScore(e.target.value)}
+            />
+            {highlightScoreError && (
+              <p className="mt-1 text-xs text-red-600">{highlightScoreError}</p>
+            )}
+          </Field>
+
+          <Field label="보정 이벤트 시각(초)">
+            <Input
+              type="number"
+              step="0.1"
+              value={correctedEventSec}
+              placeholder={highlight.eventSec.toFixed(1)}
+              onChange={(e) => setCorrectedEventSec(e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <Field label={`메모 (${memo.length}/1000)`}>
+          <Textarea
+            value={memo}
+            maxLength={1000}
+            rows={3}
+            placeholder="특이사항을 적어주세요."
+            onChange={(e) => setMemo(e.target.value)}
+          />
+        </Field>
+
+        <Button
+          type="button"
+          onClick={handleSubmit}
+          disabled={mutation.isPending}
+          className="mt-1 self-end"
+        >
+          {mutation.isPending ? "저장 중..." : "라벨 저장"}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const Field = ({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) => (
+  <label className="flex flex-col gap-1">
+    <span className="text-sm font-medium text-neutral-700">
+      {label}
+      {required && <span className="ml-0.5 text-red-500">*</span>}
+    </span>
+    {children}
+  </label>
+);
+
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            "rounded-md border px-3 py-1.5 text-sm transition-colors",
+            value === opt.value
+              ? "border-neutral-900 bg-neutral-900 font-semibold text-white"
+              : "border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50",
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -13,6 +13,8 @@ import {
   type VideoHighlight,
 } from "../api";
 import { useCreateHighlightLabel } from "../hooks";
+import { TECHNIQUE_VALUES } from "../techniques";
+import { TechniqueSelect } from "./technique-select";
 
 const TECHNIQUE_RESULTS: { value: TechniqueResult; label: string }[] = [
   { value: "NONE", label: "없음" },
@@ -27,41 +29,66 @@ const SCORES: { value: Score; label: string }[] = [
   { value: "IPPON", label: "한판" },
 ];
 
-const labelFormSchema = z.object({
-  techniqueResult: z.enum(["NONE", "ATTEMPT", "SUCCESS"]),
-  score: z.enum(["NONE", "YUKO", "WAZA_ARI", "IPPON"]),
-  technique: z.string().max(100, "기술명은 100자 이하여야 합니다."),
-  highlightScore: z
-    .string()
-    .refine(
-      (v) =>
-        v.trim() === "" ||
-        (/^\d+$/.test(v.trim()) && Number(v) >= 0 && Number(v) <= 10),
-      "0~10 사이 정수여야 합니다.",
+const createLabelFormSchema = (clipDuration: number) =>
+  z.object({
+    techniqueResult: z.enum(["NONE", "ATTEMPT", "SUCCESS"]),
+    score: z.enum(["NONE", "YUKO", "WAZA_ARI", "IPPON"]),
+    technique: z
+      .string()
+      .refine(
+        (value) => value === "" || TECHNIQUE_VALUES.has(value),
+        "목록에서 기술을 선택해주세요.",
+      ),
+    highlightScore: z
+      .string()
+      .refine(
+        (v) =>
+          v.trim() === "" ||
+          (/^\d+$/.test(v.trim()) && Number(v) >= 0 && Number(v) <= 10),
+        "0~10 사이 정수여야 합니다.",
+      ),
+    correctedEventSec: z.string().refine(
+      (value) => {
+        if (value.trim() === "") return true;
+        const seconds = Number(value);
+        return (
+          !Number.isNaN(seconds) && seconds >= 0 && seconds <= clipDuration
+        );
+      },
+      `0~${clipDuration.toFixed(1)}초 사이의 숫자를 입력해주세요.`,
     ),
-  correctedEventSec: z
-    .string()
-    .refine(
-      (v) => v.trim() === "" || !Number.isNaN(Number(v)),
-      "숫자를 입력해주세요.",
-    ),
-  memo: z.string().max(1000, "메모는 1000자 이하여야 합니다."),
-});
+    memo: z.string().max(1000, "메모는 1000자 이하여야 합니다."),
+  });
 
-type LabelFormValues = z.infer<typeof labelFormSchema>;
+type LabelFormValues = z.infer<ReturnType<typeof createLabelFormSchema>>;
 
 const formatSec = (sec: number) => `${sec.toFixed(1)}초`;
 
-const toNullable = (value: string) => (value.trim() === "" ? null : value.trim());
+const toNullable = (value: string) =>
+  value.trim() === "" ? null : value.trim();
+
+const toAbsoluteEventSec = (clipStartSec: number, relativeSec: number) =>
+  Number((clipStartSec + relativeSec).toFixed(3));
 
 interface Props {
   index: number;
   highlight: VideoHighlight;
   jobId: number;
+  onSaved?: () => void;
 }
 
-export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
+export const HighlightLabelCard = ({
+  index,
+  highlight,
+  jobId,
+  onSaved,
+}: Props) => {
   const label = highlight.latestLabel;
+  const clipDuration = Math.max(0, highlight.endSec - highlight.startSec);
+  const defaultRelativeEventSec =
+    label?.correctedEventSec != null
+      ? label.correctedEventSec - highlight.startSec
+      : null;
 
   const mutation = useCreateHighlightLabel(jobId);
 
@@ -72,20 +99,36 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
     watch,
     formState: { errors },
   } = useForm<LabelFormValues>({
-    resolver: zodResolver(labelFormSchema),
+    resolver: zodResolver(createLabelFormSchema(clipDuration)),
     defaultValues: {
       techniqueResult: label?.techniqueResult ?? "NONE",
       score: label?.score ?? "NONE",
-      technique: label?.technique ?? "",
+      technique:
+        label?.technique && TECHNIQUE_VALUES.has(label.technique)
+          ? label.technique
+          : "",
       highlightScore:
         label?.highlightScore != null ? String(label.highlightScore) : "",
       correctedEventSec:
-        label?.correctedEventSec != null ? String(label.correctedEventSec) : "",
+        defaultRelativeEventSec != null &&
+        defaultRelativeEventSec >= 0 &&
+        defaultRelativeEventSec <= clipDuration
+          ? String(Number(defaultRelativeEventSec.toFixed(3)))
+          : "",
       memo: label?.memo ?? "",
     },
   });
 
   const memoLength = watch("memo").length;
+  const correctedEventSecInput = watch("correctedEventSec");
+  const correctedEventSecNumber = Number(correctedEventSecInput);
+  const correctedAbsoluteSec =
+    correctedEventSecInput.trim() !== "" &&
+    !Number.isNaN(correctedEventSecNumber) &&
+    correctedEventSecNumber >= 0 &&
+    correctedEventSecNumber <= clipDuration
+      ? toAbsoluteEventSec(highlight.startSec, correctedEventSecNumber)
+      : null;
 
   const onSubmit = (values: LabelFormValues) => {
     const body: CreateVideoLabelBody = {
@@ -99,14 +142,20 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
       correctedEventSec:
         values.correctedEventSec.trim() === ""
           ? null
-          : Number(values.correctedEventSec),
+          : toAbsoluteEventSec(
+              highlight.startSec,
+              Number(values.correctedEventSec),
+            ),
       memo: toNullable(values.memo),
     };
 
     mutation.mutate(
       { highlightId: highlight.id, data: body },
       {
-        onSuccess: () => toast.success("라벨을 저장했어요."),
+        onSuccess: () => {
+          toast.success("라벨을 저장했어요.");
+          onSaved?.();
+        },
         onError: () => toast.error("라벨 저장에 실패했어요."),
       },
     );
@@ -119,10 +168,16 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
           <span className="text-sm font-semibold text-neutral-800">
             #{index + 1}
           </span>
-          {label && (
+          {highlight.isLabeledByCurrentUser ? (
             <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
-              라벨 있음
+              내 라벨 완료
             </span>
+          ) : (
+            label && (
+              <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-600">
+                기존 라벨 있음
+              </span>
+            )
           )}
         </div>
         <video
@@ -155,92 +210,122 @@ export const HighlightLabelCard = ({ index, highlight, jobId }: Props) => {
 
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="flex flex-col gap-3 md:w-1/2"
+        className="md:w-1/2"
+        aria-disabled={highlight.isLabeledByCurrentUser}
       >
-        <Field label="기술 결과" required>
-          <Controller
-            control={control}
-            name="techniqueResult"
-            render={({ field }) => (
-              <SegmentedControl
-                options={TECHNIQUE_RESULTS}
-                value={field.value}
-                onChange={field.onChange}
-              />
-            )}
-          />
-        </Field>
-
-        <Field label="점수">
-          <Controller
-            control={control}
-            name="score"
-            render={({ field }) => (
-              <SegmentedControl
-                options={SCORES}
-                value={field.value}
-                onChange={field.onChange}
-              />
-            )}
-          />
-        </Field>
-
-        <Field label="기술명" error={errors.technique?.message}>
-          <Input
-            {...register("technique")}
-            maxLength={100}
-            placeholder="예) 업어치기"
-            aria-invalid={!!errors.technique}
-          />
-        </Field>
-
-        <div className="grid grid-cols-2 gap-3">
-          <Field
-            label="하이라이트 점수 (0~10)"
-            error={errors.highlightScore?.message}
-          >
-            <Input
-              {...register("highlightScore")}
-              type="number"
-              min={0}
-              max={10}
-              step={1}
-              placeholder="0~10"
-              aria-invalid={!!errors.highlightScore}
-            />
-          </Field>
-
-          <Field
-            label="보정 이벤트 시각(초)"
-            error={errors.correctedEventSec?.message}
-          >
-            <Input
-              {...register("correctedEventSec")}
-              type="number"
-              step="0.1"
-              placeholder={highlight.eventSec.toFixed(1)}
-              aria-invalid={!!errors.correctedEventSec}
-            />
-          </Field>
-        </div>
-
-        <Field label={`메모 (${memoLength}/1000)`} error={errors.memo?.message}>
-          <Textarea
-            {...register("memo")}
-            maxLength={1000}
-            rows={3}
-            placeholder="특이사항을 적어주세요."
-            aria-invalid={!!errors.memo}
-          />
-        </Field>
-
-        <Button
-          type="submit"
-          disabled={mutation.isPending}
-          className="mt-1 self-end"
+        <fieldset
+          disabled={highlight.isLabeledByCurrentUser}
+          className="flex flex-col gap-3 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {mutation.isPending ? "저장 중..." : "라벨 저장"}
-        </Button>
+          {highlight.isLabeledByCurrentUser && (
+            <p className="rounded-md bg-green-50 px-3 py-2 text-sm font-medium text-green-700">
+              이미 라벨링한 하이라이트입니다.
+            </p>
+          )}
+          <Field label="기술 결과" required>
+            <Controller
+              control={control}
+              name="techniqueResult"
+              render={({ field }) => (
+                <SegmentedControl
+                  options={TECHNIQUE_RESULTS}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Field>
+
+          <Field label="점수">
+            <Controller
+              control={control}
+              name="score"
+              render={({ field }) => (
+                <SegmentedControl
+                  options={SCORES}
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Field>
+
+          <Field label="기술명" error={errors.technique?.message}>
+            <Controller
+              control={control}
+              name="technique"
+              render={({ field }) => (
+                <TechniqueSelect
+                  value={field.value}
+                  onChange={field.onChange}
+                  invalid={!!errors.technique}
+                />
+              )}
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="하이라이트 점수 (0~10)"
+              error={errors.highlightScore?.message}
+            >
+              <Input
+                {...register("highlightScore")}
+                type="number"
+                min={0}
+                max={10}
+                step={1}
+                placeholder="0~10"
+                aria-invalid={!!errors.highlightScore}
+              />
+            </Field>
+
+            <Field
+              label="클립 내 이벤트 시각(초)"
+              error={errors.correctedEventSec?.message}
+            >
+              <>
+                <Input
+                  {...register("correctedEventSec")}
+                  type="number"
+                  min={0}
+                  max={clipDuration}
+                  step="0.1"
+                  placeholder={(
+                    highlight.eventSec - highlight.startSec
+                  ).toFixed(1)}
+                  aria-invalid={!!errors.correctedEventSec}
+                />
+                <span className="text-xs text-neutral-500">
+                  클립 시작 기준 0~{clipDuration.toFixed(1)}초
+                  {correctedAbsoluteSec != null &&
+                    ` · 원본 기준 ${correctedAbsoluteSec.toFixed(1)}초로 저장`}
+                </span>
+              </>
+            </Field>
+          </div>
+
+          <Field
+            label={`메모 (${memoLength}/1000)`}
+            error={errors.memo?.message}
+          >
+            <Textarea
+              {...register("memo")}
+              maxLength={1000}
+              rows={3}
+              placeholder="특이사항을 적어주세요."
+              aria-invalid={!!errors.memo}
+            />
+          </Field>
+
+          <Button
+            type="submit"
+            disabled={mutation.isPending}
+            className="mt-1 self-end"
+          >
+            {mutation.isPending ? "저장 중..." : "라벨 저장"}
+          </Button>
+        </fieldset>
       </form>
     </div>
   );

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -208,11 +208,7 @@ export const HighlightLabelCard = ({
         </dl>
       </div>
 
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="md:w-1/2"
-        aria-disabled={highlight.isLabeledByCurrentUser}
-      >
+      <form onSubmit={handleSubmit(onSubmit)} className="md:w-1/2">
         <fieldset
           disabled={highlight.isLabeledByCurrentUser}
           className="flex flex-col gap-3 disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/admin/src/features/video/ui/technique-select.tsx
+++ b/apps/admin/src/features/video/ui/technique-select.tsx
@@ -1,0 +1,208 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+import { TECHNIQUE_GROUPS } from "../techniques";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  invalid?: boolean;
+}
+
+const allOptions = TECHNIQUE_GROUPS.flatMap((group) => group.options);
+
+const findOption = (value: string) =>
+  allOptions.find((option) => option.value === value);
+
+export const TechniqueSelect = ({ value, onChange, invalid }: Props) => {
+  const listboxId = useId();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const selectedOption = findOption(value);
+  const [query, setQuery] = useState(selectedOption?.label ?? "");
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const filteredGroups = useMemo(() => {
+    const terms = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return TECHNIQUE_GROUPS;
+
+    return TECHNIQUE_GROUPS.map((group) => ({
+      ...group,
+      options: group.options.filter((option) => {
+        const searchable =
+          `${option.value} ${option.label}`.toLocaleLowerCase();
+        return terms.every((term) => searchable.includes(term));
+      }),
+    })).filter((group) => group.options.length > 0);
+  }, [query]);
+
+  const filteredOptions = useMemo(
+    () => filteredGroups.flatMap((group) => group.options),
+    [filteredGroups],
+  );
+
+  useEffect(() => {
+    if (!isOpen) setQuery(selectedOption?.label ?? "");
+  }, [isOpen, selectedOption?.label]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, []);
+
+  const selectValue = (nextValue: string) => {
+    onChange(nextValue);
+    setQuery(findOption(nextValue)?.label ?? "");
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setIsOpen(true);
+      setActiveIndex((current) =>
+        isOpen
+          ? Math.min(current + 1, Math.max(filteredOptions.length - 1, 0))
+          : 0,
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) => Math.max(current - 1, 0));
+    } else if (
+      event.key === "Enter" &&
+      isOpen &&
+      filteredOptions[activeIndex]
+    ) {
+      event.preventDefault();
+      selectValue(filteredOptions[activeIndex].value);
+    } else if (event.key === "Escape") {
+      setIsOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div
+        className={cn(
+          "flex h-10 items-center rounded-md border border-input bg-background ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+          invalid && "border-red-500",
+        )}
+      >
+        <Search className="ml-3 h-4 w-4 shrink-0 text-neutral-400" />
+        <input
+          ref={inputRef}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-invalid={invalid}
+          value={query}
+          placeholder="기술명 검색"
+          className="h-full min-w-0 flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground"
+          onFocus={(event) => {
+            setIsOpen(true);
+            if (selectedOption) {
+              setQuery("");
+              event.currentTarget.select();
+            }
+          }}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setIsOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          aria-label="기술 목록 열기"
+          onClick={() => {
+            setIsOpen((open) => !open);
+            inputRef.current?.focus();
+          }}
+          className="flex h-full items-center px-3 text-neutral-400 hover:text-neutral-700"
+        >
+          <ChevronDown className="h-4 w-4" />
+        </button>
+      </div>
+
+      {isOpen && (
+        <div
+          id={listboxId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-neutral-200 bg-white py-1 shadow-lg"
+        >
+          <button
+            type="button"
+            role="option"
+            aria-selected={value === ""}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => selectValue("")}
+            className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-neutral-500 hover:bg-neutral-50"
+          >
+            기술 선택 안 함{value === "" && <Check className="h-4 w-4" />}
+          </button>
+
+          {filteredGroups.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-neutral-500">
+              검색 결과가 없습니다.
+            </p>
+          ) : (
+            filteredGroups.map((group) => (
+              <div key={group.label}>
+                <p className="sticky top-0 bg-neutral-50 px-3 py-1.5 text-xs font-semibold text-neutral-500">
+                  {group.label}
+                </p>
+                {group.options.map((option) => {
+                  const optionIndex = filteredOptions.findIndex(
+                    (item) => item.value === option.value,
+                  );
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      role="option"
+                      aria-selected={value === option.value}
+                      onMouseEnter={() => setActiveIndex(optionIndex)}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => selectValue(option.value)}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm",
+                        optionIndex === activeIndex
+                          ? "bg-neutral-100 text-neutral-900"
+                          : "text-neutral-700 hover:bg-neutral-50",
+                      )}
+                    >
+                      <span>{option.label}</span>
+                      {value === option.value && (
+                        <Check className="h-4 w-4 shrink-0" />
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,9 +1,21 @@
+import axios from "axios";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import "@/app/index.css";
 
 import StandaloneApp from "@/app/StandaloneApp";
+
+// dev: orval 생성 클라이언트가 하드코딩한 절대 URL(https://api.uosjudo.com)을
+// 상대경로로 바꿔 Vite dev 프록시(/api)를 타게 한다 → 동일 출처가 되어 쿠키 인증 동작.
+if (import.meta.env.DEV) {
+  axios.interceptors.request.use((config) => {
+    if (config.url) {
+      config.url = config.url.replace(/^https?:\/\/api\.uosjudo\.com/i, "");
+    }
+    return config;
+  });
+}
 
 const rootElement = document.getElementById("root");
 

--- a/apps/admin/src/pages/video/detail.tsx
+++ b/apps/admin/src/pages/video/detail.tsx
@@ -1,7 +1,7 @@
 import { RouterUrl } from "@/app/routers/router-url";
 import { PageHeader } from "@/components/layouts/PageHeader";
 import { HighlightLabelCard } from "@/features/video/ui/highlight-label-card";
-import { useVideoJobDetail } from "@/features/video/hooks";
+import { useVideoEvents, useVideoJobDetail } from "@/features/video/hooks";
 import { ArrowLeft, Film } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 
@@ -10,6 +10,14 @@ export const VideoLabelingDetailPage = () => {
   const jobId = Number(id);
 
   const { data: job, isLoading, isError } = useVideoJobDetail(jobId);
+  const {
+    data: events,
+    isLoading: isEventsLoading,
+    isError: isEventsError,
+  } = useVideoEvents(jobId);
+  const labelingStatus = new Map(
+    events?.map((event) => [event.highlightId, event.isLabeledByCurrentUser]),
+  );
 
   return (
     <div className="space-y-6 p-6">
@@ -27,22 +35,30 @@ export const VideoLabelingDetailPage = () => {
         description="각 하이라이트 클립을 보고 라벨을 저장하세요."
       />
 
-      {isLoading && <p className="text-neutral-500">불러오는 중...</p>}
-      {isError && (
-        <p className="text-red-600">영상을 불러오지 못했어요. 다시 시도해주세요.</p>
+      {(isLoading || isEventsLoading) && (
+        <p className="text-neutral-500">불러오는 중...</p>
+      )}
+      {(isError || isEventsError) && (
+        <p className="text-red-600">
+          영상을 불러오지 못했어요. 다시 시도해주세요.
+        </p>
       )}
 
       {job && job.highlights.length === 0 && (
         <p className="text-neutral-500">하이라이트가 없는 영상이에요.</p>
       )}
 
-      {job && job.highlights.length > 0 && (
+      {job && events && job.highlights.length > 0 && (
         <div className="flex flex-col gap-4">
           {job.highlights.map((highlight, index) => (
             <HighlightLabelCard
               key={highlight.id}
               index={index}
-              highlight={highlight}
+              highlight={{
+                ...highlight,
+                isLabeledByCurrentUser:
+                  labelingStatus.get(highlight.id) ?? false,
+              }}
               jobId={job.id}
             />
           ))}

--- a/apps/admin/src/pages/video/detail.tsx
+++ b/apps/admin/src/pages/video/detail.tsx
@@ -1,0 +1,53 @@
+import { RouterUrl } from "@/app/routers/router-url";
+import { PageHeader } from "@/components/layouts/PageHeader";
+import { HighlightLabelCard } from "@/features/video/ui/highlight-label-card";
+import { useVideoJobDetail } from "@/features/video/hooks";
+import { ArrowLeft, Film } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+
+export const VideoLabelingDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const jobId = Number(id);
+
+  const { data: job, isLoading, isError } = useVideoJobDetail(jobId);
+
+  return (
+    <div className="space-y-6 p-6">
+      <Link
+        to={RouterUrl.영상.목록}
+        className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-800"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        목록으로
+      </Link>
+
+      <PageHeader
+        icon={Film}
+        title={job?.originalFilename ?? "영상 라벨링"}
+        description="각 하이라이트 클립을 보고 라벨을 저장하세요."
+      />
+
+      {isLoading && <p className="text-neutral-500">불러오는 중...</p>}
+      {isError && (
+        <p className="text-red-600">영상을 불러오지 못했어요. 다시 시도해주세요.</p>
+      )}
+
+      {job && job.highlights.length === 0 && (
+        <p className="text-neutral-500">하이라이트가 없는 영상이에요.</p>
+      )}
+
+      {job && job.highlights.length > 0 && (
+        <div className="flex flex-col gap-4">
+          {job.highlights.map((highlight, index) => (
+            <HighlightLabelCard
+              key={highlight.id}
+              index={index}
+              highlight={highlight}
+              jobId={job.id}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/admin/src/pages/video/fullpage.tsx
+++ b/apps/admin/src/pages/video/fullpage.tsx
@@ -119,7 +119,7 @@ export const VideoLabelingFullpage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-neutral-950 text-sm text-neutral-300">
+      <div className="flex min-h-screen items-center justify-center bg-neutral-100 text-sm text-neutral-600">
         라벨링 데이터를 불러오는 중...
       </div>
     );
@@ -127,7 +127,7 @@ export const VideoLabelingFullpage = () => {
 
   if (isError || !jobQuery.data) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-neutral-950 px-6 text-center text-white">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-neutral-100 px-6 text-center text-neutral-900">
         <p>영상 라벨링 데이터를 불러오지 못했습니다.</p>
         <Button asChild variant="secondary">
           <Link to={RouterUrl.영상.목록}>목록으로 돌아가기</Link>
@@ -137,14 +137,14 @@ export const VideoLabelingFullpage = () => {
   }
 
   return (
-    <div className="min-h-screen bg-neutral-950 text-white">
-      <header className="sticky top-0 z-30 border-b border-white/10 bg-neutral-950/95 backdrop-blur">
+    <div className="min-h-screen bg-neutral-100 text-neutral-900">
+      <header className="sticky top-0 z-30 border-b border-neutral-200 bg-white/95 shadow-sm backdrop-blur">
         <div className="mx-auto flex max-w-screen-2xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
           <div className="flex min-w-0 items-center gap-3">
             <Link
               to={RouterUrl.영상.목록}
               aria-label="영상 목록으로"
-              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 hover:text-white"
+              className="rounded-md p-2 text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900"
             >
               <ArrowLeft className="h-5 w-5" />
             </Link>
@@ -152,7 +152,7 @@ export const VideoLabelingFullpage = () => {
               <h1 className="truncate text-sm font-semibold sm:text-base">
                 {jobQuery.data.originalFilename}
               </h1>
-              <p className="text-xs text-neutral-400">
+              <p className="text-xs text-neutral-500">
                 완료 {labeledCount}/{highlights.length}
               </p>
             </div>
@@ -164,7 +164,7 @@ export const VideoLabelingFullpage = () => {
               aria-label="이전 하이라이트"
               disabled={activeIndex <= 0}
               onClick={() => openHighlight(highlights[activeIndex - 1].id)}
-              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 disabled:opacity-30"
+              className="rounded-md p-2 text-neutral-600 hover:bg-neutral-100 disabled:opacity-30"
             >
               <ChevronLeft className="h-5 w-5" />
             </button>
@@ -176,7 +176,7 @@ export const VideoLabelingFullpage = () => {
               aria-label="다음 하이라이트"
               disabled={activeIndex >= highlights.length - 1}
               onClick={() => openHighlight(highlights[activeIndex + 1].id)}
-              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 disabled:opacity-30"
+              className="rounded-md p-2 text-neutral-600 hover:bg-neutral-100 disabled:opacity-30"
             >
               <ChevronRight className="h-5 w-5" />
             </button>
@@ -186,9 +186,9 @@ export const VideoLabelingFullpage = () => {
 
       <main className="mx-auto max-w-screen-2xl px-3 py-4 sm:px-6 sm:py-6">
         {highlights.length === 0 ? (
-          <section className="rounded-xl border border-white/10 bg-white/5 p-8 text-center">
+          <section className="rounded-xl border border-neutral-200 bg-white p-8 text-center shadow-sm">
             <ListVideo className="mx-auto h-8 w-8 text-neutral-400" />
-            <p className="mt-3 text-neutral-300">
+            <p className="mt-3 text-neutral-600">
               라벨링할 하이라이트가 없습니다.
             </p>
             {nextJob && (
@@ -202,7 +202,7 @@ export const VideoLabelingFullpage = () => {
             <section className="min-w-0">
               {isCurrentJobComplete &&
                 activeHighlight.isLabeledByCurrentUser && (
-                  <div className="mb-4 flex flex-col gap-3 rounded-xl border border-green-500/30 bg-green-500/10 p-4 text-sm text-green-100 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="mb-4 flex flex-col gap-3 rounded-xl border border-green-200 bg-green-50 p-4 text-sm text-green-800 sm:flex-row sm:items-center sm:justify-between">
                     <span>이 영상의 모든 하이라이트를 라벨링했습니다.</span>
                     {nextJob ? (
                       <Button size="sm" onClick={openNextJob}>
@@ -225,8 +225,8 @@ export const VideoLabelingFullpage = () => {
             </section>
 
             <aside className="hidden lg:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-3">
-                <h2 className="mb-2 px-2 text-sm font-semibold text-neutral-200">
+              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto rounded-xl border border-neutral-200 bg-white p-3 shadow-sm">
+                <h2 className="mb-2 px-2 text-sm font-semibold text-neutral-700">
                   하이라이트 목록
                 </h2>
                 <div className="space-y-1">
@@ -238,8 +238,8 @@ export const VideoLabelingFullpage = () => {
                       className={cn(
                         "flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm",
                         index === activeIndex
-                          ? "bg-white text-neutral-950"
-                          : "text-neutral-300 hover:bg-white/10",
+                          ? "bg-neutral-900 text-white"
+                          : "text-neutral-600 hover:bg-neutral-100",
                       )}
                     >
                       <span>하이라이트 {index + 1}</span>

--- a/apps/admin/src/pages/video/fullpage.tsx
+++ b/apps/admin/src/pages/video/fullpage.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo } from "react";
+import {
+  ArrowLeft,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  ListVideo,
+} from "lucide-react";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
+
+import { RouterUrl } from "@/app/routers/router-url";
+import { Button } from "@/components/ui/button";
+import {
+  useVideoEvents,
+  useVideoJobDetail,
+  useVideoJobs,
+} from "@/features/video/hooks";
+import { HighlightLabelCard } from "@/features/video/ui/highlight-label-card";
+import { cn } from "@/shared/lib/utils";
+
+export const VideoLabelingFullpage = () => {
+  const { jobId: jobIdParam } = useParams<{ jobId: string }>();
+  const jobId = Number(jobIdParam);
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedHighlightId = Number(searchParams.get("highlightId"));
+
+  const jobQuery = useVideoJobDetail(jobId);
+  const eventsQuery = useVideoEvents(jobId);
+  const jobsQuery = useVideoJobs();
+
+  const highlights = useMemo(() => {
+    if (!jobQuery.data || !eventsQuery.data) return [];
+    const eventStatus = new Map(
+      eventsQuery.data.map((event) => [
+        event.highlightId,
+        event.isLabeledByCurrentUser,
+      ]),
+    );
+    return jobQuery.data.highlights.map((highlight) => ({
+      ...highlight,
+      isLabeledByCurrentUser: eventStatus.get(highlight.id) ?? false,
+    }));
+  }, [eventsQuery.data, jobQuery.data]);
+
+  const requestedIndex = highlights.findIndex(
+    (highlight) => highlight.id === requestedHighlightId,
+  );
+  const firstUnlabeledIndex = highlights.findIndex(
+    (highlight) => !highlight.isLabeledByCurrentUser,
+  );
+  const activeIndex =
+    requestedIndex >= 0
+      ? requestedIndex
+      : firstUnlabeledIndex >= 0
+        ? firstUnlabeledIndex
+        : 0;
+  const activeHighlight = highlights[activeIndex];
+
+  const currentJobIndex =
+    jobsQuery.data?.findIndex((job) => job.id === jobId) ?? -1;
+  const nextJob =
+    currentJobIndex >= 0
+      ? jobsQuery.data
+          ?.slice(currentJobIndex + 1)
+          .find((job) => job.status === "done" && job.highlightCount > 0)
+      : undefined;
+
+  const labeledCount = highlights.filter(
+    (highlight) => highlight.isLabeledByCurrentUser,
+  ).length;
+  const isCurrentJobComplete =
+    highlights.length > 0 && labeledCount === highlights.length;
+
+  useEffect(() => {
+    if (activeHighlight && requestedIndex < 0) {
+      setSearchParams(
+        { highlightId: String(activeHighlight.id) },
+        { replace: true },
+      );
+    }
+  }, [activeHighlight, requestedIndex, setSearchParams]);
+
+  const openHighlight = (highlightId: number, replace = false) => {
+    setSearchParams({ highlightId: String(highlightId) }, { replace });
+  };
+
+  const openNextJob = () => {
+    if (!nextJob) return;
+    navigate(RouterUrl.영상.풀페이지({ jobId: nextJob.id }), {
+      replace: true,
+    });
+  };
+
+  const handleSaved = () => {
+    const remainingHighlights = [
+      ...highlights.slice(activeIndex + 1),
+      ...highlights.slice(0, activeIndex),
+    ];
+    const nextHighlight = remainingHighlights.find(
+      (highlight) => !highlight.isLabeledByCurrentUser,
+    );
+
+    if (nextHighlight) {
+      openHighlight(nextHighlight.id, true);
+      return;
+    }
+    openNextJob();
+  };
+
+  const isLoading =
+    jobQuery.isLoading || eventsQuery.isLoading || jobsQuery.isLoading;
+  const isError = jobQuery.isError || eventsQuery.isError || jobsQuery.isError;
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-neutral-950 text-sm text-neutral-300">
+        라벨링 데이터를 불러오는 중...
+      </div>
+    );
+  }
+
+  if (isError || !jobQuery.data) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-neutral-950 px-6 text-center text-white">
+        <p>영상 라벨링 데이터를 불러오지 못했습니다.</p>
+        <Button asChild variant="secondary">
+          <Link to={RouterUrl.영상.목록}>목록으로 돌아가기</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-white">
+      <header className="sticky top-0 z-30 border-b border-white/10 bg-neutral-950/95 backdrop-blur">
+        <div className="mx-auto flex max-w-screen-2xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+          <div className="flex min-w-0 items-center gap-3">
+            <Link
+              to={RouterUrl.영상.목록}
+              aria-label="영상 목록으로"
+              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 hover:text-white"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Link>
+            <div className="min-w-0">
+              <h1 className="truncate text-sm font-semibold sm:text-base">
+                {jobQuery.data.originalFilename}
+              </h1>
+              <p className="text-xs text-neutral-400">
+                완료 {labeledCount}/{highlights.length}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="이전 하이라이트"
+              disabled={activeIndex <= 0}
+              onClick={() => openHighlight(highlights[activeIndex - 1].id)}
+              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 disabled:opacity-30"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+            <span className="min-w-14 text-center text-sm tabular-nums">
+              {highlights.length > 0 ? activeIndex + 1 : 0}/{highlights.length}
+            </span>
+            <button
+              type="button"
+              aria-label="다음 하이라이트"
+              disabled={activeIndex >= highlights.length - 1}
+              onClick={() => openHighlight(highlights[activeIndex + 1].id)}
+              className="rounded-md p-2 text-neutral-300 hover:bg-white/10 disabled:opacity-30"
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-screen-2xl px-3 py-4 sm:px-6 sm:py-6">
+        {highlights.length === 0 ? (
+          <section className="rounded-xl border border-white/10 bg-white/5 p-8 text-center">
+            <ListVideo className="mx-auto h-8 w-8 text-neutral-400" />
+            <p className="mt-3 text-neutral-300">
+              라벨링할 하이라이트가 없습니다.
+            </p>
+            {nextJob && (
+              <Button className="mt-4" onClick={openNextJob}>
+                다음 작업으로 이동
+              </Button>
+            )}
+          </section>
+        ) : (
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_17rem]">
+            <section className="min-w-0">
+              {isCurrentJobComplete &&
+                activeHighlight.isLabeledByCurrentUser && (
+                  <div className="mb-4 flex flex-col gap-3 rounded-xl border border-green-500/30 bg-green-500/10 p-4 text-sm text-green-100 sm:flex-row sm:items-center sm:justify-between">
+                    <span>이 영상의 모든 하이라이트를 라벨링했습니다.</span>
+                    {nextJob ? (
+                      <Button size="sm" onClick={openNextJob}>
+                        다음 작업으로 이동
+                      </Button>
+                    ) : (
+                      <Button asChild size="sm" variant="secondary">
+                        <Link to={RouterUrl.영상.목록}>목록으로 돌아가기</Link>
+                      </Button>
+                    )}
+                  </div>
+                )}
+              <HighlightLabelCard
+                key={activeHighlight.id}
+                index={activeIndex}
+                highlight={activeHighlight}
+                jobId={jobId}
+                onSaved={handleSaved}
+              />
+            </section>
+
+            <aside className="hidden lg:block">
+              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-3">
+                <h2 className="mb-2 px-2 text-sm font-semibold text-neutral-200">
+                  하이라이트 목록
+                </h2>
+                <div className="space-y-1">
+                  {highlights.map((highlight, index) => (
+                    <button
+                      key={highlight.id}
+                      type="button"
+                      onClick={() => openHighlight(highlight.id)}
+                      className={cn(
+                        "flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm",
+                        index === activeIndex
+                          ? "bg-white text-neutral-950"
+                          : "text-neutral-300 hover:bg-white/10",
+                      )}
+                    >
+                      <span>하이라이트 {index + 1}</span>
+                      {highlight.isLabeledByCurrentUser && (
+                        <Check className="h-4 w-4 text-green-500" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </aside>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};

--- a/apps/admin/src/pages/video/fullpage.tsx
+++ b/apps/admin/src/pages/video/fullpage.tsx
@@ -34,6 +34,23 @@ export const VideoLabelingFullpage = () => {
   const eventsQuery = useVideoEvents(jobId);
   const jobsQuery = useVideoJobs();
 
+  const navigableJobs = useMemo(
+    () =>
+      [...(jobsQuery.data ?? [])]
+        .filter((job) => job.status === "done" && job.highlightCount > 0)
+        .sort((left, right) => left.id - right.id),
+    [jobsQuery.data],
+  );
+  const currentJobIndex = navigableJobs.findIndex((job) => job.id === jobId);
+  const previousJob =
+    currentJobIndex > 0 ? navigableJobs[currentJobIndex - 1] : undefined;
+  const nextJob =
+    currentJobIndex >= 0 && currentJobIndex < navigableJobs.length - 1
+      ? navigableJobs[currentJobIndex + 1]
+      : undefined;
+  const previousJobEventsQuery = useVideoEvents(previousJob?.id ?? 0);
+  const nextJobEventsQuery = useVideoEvents(nextJob?.id ?? 0);
+
   const highlights = useMemo(() => {
     if (!jobQuery.data || !eventsQuery.data) return [];
     const eventStatus = new Map(
@@ -62,15 +79,6 @@ export const VideoLabelingFullpage = () => {
         : 0;
   const activeHighlight = highlights[activeIndex];
 
-  const currentJobIndex =
-    jobsQuery.data?.findIndex((job) => job.id === jobId) ?? -1;
-  const nextJob =
-    currentJobIndex >= 0
-      ? jobsQuery.data
-          ?.slice(currentJobIndex + 1)
-          .find((job) => job.status === "done" && job.highlightCount > 0)
-      : undefined;
-
   const labeledCount = highlights.filter(
     (highlight) => highlight.isLabeledByCurrentUser,
   ).length;
@@ -95,6 +103,39 @@ export const VideoLabelingFullpage = () => {
     navigate(RouterUrl.영상.풀페이지({ jobId: nextJob.id }), {
       replace: true,
     });
+  };
+
+  const openJobHighlight = (
+    targetJobId: number,
+    highlightId: number,
+    replace = false,
+  ) => {
+    navigate(
+      `${RouterUrl.영상.풀페이지({ jobId: targetJobId })}?highlightId=${highlightId}`,
+      { replace },
+    );
+  };
+
+  const previousJobLastHighlight = previousJobEventsQuery.data?.at(-1);
+  const nextJobFirstHighlight = nextJobEventsQuery.data?.[0];
+  const canMovePrevious = activeIndex > 0 || !!previousJobLastHighlight;
+  const canMoveNext =
+    activeIndex < highlights.length - 1 || !!nextJobFirstHighlight;
+
+  const movePrevious = () => {
+    if (activeIndex > 0) {
+      openHighlight(highlights[activeIndex - 1].id);
+    } else if (previousJob && previousJobLastHighlight) {
+      openJobHighlight(previousJob.id, previousJobLastHighlight.highlightId);
+    }
+  };
+
+  const moveNext = () => {
+    if (activeIndex < highlights.length - 1) {
+      openHighlight(highlights[activeIndex + 1].id);
+    } else if (nextJob && nextJobFirstHighlight) {
+      openJobHighlight(nextJob.id, nextJobFirstHighlight.highlightId);
+    }
   };
 
   const handleSaved = () => {
@@ -162,8 +203,8 @@ export const VideoLabelingFullpage = () => {
             <button
               type="button"
               aria-label="이전 하이라이트"
-              disabled={activeIndex <= 0}
-              onClick={() => openHighlight(highlights[activeIndex - 1].id)}
+              disabled={!canMovePrevious}
+              onClick={movePrevious}
               className="rounded-md p-2 text-neutral-600 hover:bg-neutral-100 disabled:opacity-30"
             >
               <ChevronLeft className="h-5 w-5" />
@@ -174,8 +215,8 @@ export const VideoLabelingFullpage = () => {
             <button
               type="button"
               aria-label="다음 하이라이트"
-              disabled={activeIndex >= highlights.length - 1}
-              onClick={() => openHighlight(highlights[activeIndex + 1].id)}
+              disabled={!canMoveNext}
+              onClick={moveNext}
               className="rounded-md p-2 text-neutral-600 hover:bg-neutral-100 disabled:opacity-30"
             >
               <ChevronRight className="h-5 w-5" />
@@ -222,6 +263,31 @@ export const VideoLabelingFullpage = () => {
                 jobId={jobId}
                 onSaved={handleSaved}
               />
+              <nav
+                aria-label="하이라이트 이동"
+                className="mt-4 flex items-center justify-between gap-3"
+              >
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!canMovePrevious}
+                  onClick={movePrevious}
+                  className="bg-white"
+                >
+                  <ChevronLeft />
+                  이전 하이라이트
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!canMoveNext}
+                  onClick={moveNext}
+                  className="bg-white"
+                >
+                  다음 하이라이트
+                  <ChevronRight />
+                </Button>
+              </nav>
             </section>
 
             <aside className="hidden lg:block">

--- a/apps/admin/src/pages/video/index.tsx
+++ b/apps/admin/src/pages/video/index.tsx
@@ -1,11 +1,11 @@
 import { RouterUrl } from "@/app/routers/router-url";
 import { PageHeader } from "@/components/layouts/PageHeader";
-import { cn } from "@/shared/lib/utils";
 import {
-  type VideoJobStatus,
   type VideoJobListItem,
+  type VideoJobStatus,
 } from "@/features/video/api";
 import { useVideoJobs } from "@/features/video/hooks";
+import { cn } from "@/shared/lib/utils";
 import { Expand, Film } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -91,11 +91,11 @@ const JobRow = ({ job }: { job: VideoJobListItem }) => {
       </Link>
       {job.status === "done" && job.highlightCount > 0 && (
         <Link
-          하이라이트 전체화면uterUrl.영상.풀페이지({ jobId: job.id })}
+          to={RouterUrl.영상.풀페이지({ jobId: job.id })}
           className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-neutral-900 px-3 py-2 text-sm font-semibold text-white hover:bg-neutral-700"
         >
           <Expand className="h-4 w-4" />
-          집중 라벨링
+          전체화면으로
         </Link>
       )}
     </li>

--- a/apps/admin/src/pages/video/index.tsx
+++ b/apps/admin/src/pages/video/index.tsx
@@ -6,16 +6,18 @@ import {
   type VideoJobListItem,
 } from "@/features/video/api";
 import { useVideoJobs } from "@/features/video/hooks";
-import { Film } from "lucide-react";
+import { Expand, Film } from "lucide-react";
 import { Link } from "react-router-dom";
 
-const STATUS_META: Record<VideoJobStatus, { label: string; className: string }> =
-  {
-    done: { label: "완료", className: "bg-green-100 text-green-700" },
-    processing: { label: "처리중", className: "bg-blue-100 text-blue-700" },
-    uploaded: { label: "업로드됨", className: "bg-neutral-100 text-neutral-600" },
-    failed: { label: "실패", className: "bg-red-100 text-red-700" },
-  };
+const STATUS_META: Record<
+  VideoJobStatus,
+  { label: string; className: string }
+> = {
+  done: { label: "완료", className: "bg-green-100 text-green-700" },
+  processing: { label: "처리중", className: "bg-blue-100 text-blue-700" },
+  uploaded: { label: "업로드됨", className: "bg-neutral-100 text-neutral-600" },
+  failed: { label: "실패", className: "bg-red-100 text-red-700" },
+};
 
 const formatDate = (value: string) =>
   new Date(value).toLocaleString("ko-KR", {
@@ -36,7 +38,9 @@ export const VideoLabelingPage = () => {
 
       {isLoading && <p className="text-neutral-500">불러오는 중...</p>}
       {isError && (
-        <p className="text-red-600">목록을 불러오지 못했어요. 다시 시도해주세요.</p>
+        <p className="text-red-600">
+          목록을 불러오지 못했어요. 다시 시도해주세요.
+        </p>
       )}
 
       {jobs && jobs.length === 0 && (
@@ -58,10 +62,10 @@ const JobRow = ({ job }: { job: VideoJobListItem }) => {
   const status = STATUS_META[job.status];
 
   return (
-    <li>
+    <li className="flex flex-col gap-2 rounded-xl border bg-white p-4 shadow-sm sm:flex-row sm:items-center">
       <Link
         to={RouterUrl.영상.상세({ id: job.id })}
-        className="flex items-center justify-between rounded-xl border bg-white p-4 shadow-sm transition-colors hover:bg-neutral-50"
+        className="flex min-w-0 flex-1 items-center justify-between transition-colors hover:text-neutral-600"
       >
         <div className="flex min-w-0 flex-col gap-1">
           <span className="truncate font-semibold text-neutral-900">
@@ -85,6 +89,15 @@ const JobRow = ({ job }: { job: VideoJobListItem }) => {
           </span>
         </div>
       </Link>
+      {job.status === "done" && job.highlightCount > 0 && (
+        <Link
+          하이라이트 전체화면uterUrl.영상.풀페이지({ jobId: job.id })}
+          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-neutral-900 px-3 py-2 text-sm font-semibold text-white hover:bg-neutral-700"
+        >
+          <Expand className="h-4 w-4" />
+          집중 라벨링
+        </Link>
+      )}
     </li>
   );
 };

--- a/apps/admin/src/pages/video/index.tsx
+++ b/apps/admin/src/pages/video/index.tsx
@@ -1,0 +1,90 @@
+import { RouterUrl } from "@/app/routers/router-url";
+import { PageHeader } from "@/components/layouts/PageHeader";
+import { cn } from "@/shared/lib/utils";
+import {
+  type VideoJobStatus,
+  type VideoJobListItem,
+} from "@/features/video/api";
+import { useVideoJobs } from "@/features/video/hooks";
+import { Film } from "lucide-react";
+import { Link } from "react-router-dom";
+
+const STATUS_META: Record<VideoJobStatus, { label: string; className: string }> =
+  {
+    done: { label: "완료", className: "bg-green-100 text-green-700" },
+    processing: { label: "처리중", className: "bg-blue-100 text-blue-700" },
+    uploaded: { label: "업로드됨", className: "bg-neutral-100 text-neutral-600" },
+    failed: { label: "실패", className: "bg-red-100 text-red-700" },
+  };
+
+const formatDate = (value: string) =>
+  new Date(value).toLocaleString("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+export const VideoLabelingPage = () => {
+  const { data: jobs, isLoading, isError } = useVideoJobs();
+
+  return (
+    <div className="space-y-6 p-6">
+      <PageHeader
+        icon={Film}
+        title="하이라이트 라벨링"
+        description="분석된 영상 하이라이트를 검토하고 라벨을 달아요."
+      />
+
+      {isLoading && <p className="text-neutral-500">불러오는 중...</p>}
+      {isError && (
+        <p className="text-red-600">목록을 불러오지 못했어요. 다시 시도해주세요.</p>
+      )}
+
+      {jobs && jobs.length === 0 && (
+        <p className="text-neutral-500">아직 등록된 영상이 없어요.</p>
+      )}
+
+      {jobs && jobs.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {jobs.map((job) => (
+            <JobRow key={job.id} job={job} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const JobRow = ({ job }: { job: VideoJobListItem }) => {
+  const status = STATUS_META[job.status];
+
+  return (
+    <li>
+      <Link
+        to={RouterUrl.영상.상세({ id: job.id })}
+        className="flex items-center justify-between rounded-xl border bg-white p-4 shadow-sm transition-colors hover:bg-neutral-50"
+      >
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="truncate font-semibold text-neutral-900">
+            {job.originalFilename}
+          </span>
+          <span className="text-xs text-neutral-500">
+            {formatDate(job.createdAt)}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <span className="text-sm text-neutral-600">
+            하이라이트 {job.highlightCount}개
+          </span>
+          <span
+            className={cn(
+              "rounded-full px-2.5 py-1 text-xs font-medium",
+              status.className,
+            )}
+          >
+            {status.label}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+};

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -43,6 +43,21 @@ export default defineConfig({
         rewrite: (path) => path,
         secure: false,
         ws: true,
+        // prod api(https)를 프록시할 때, 인증 쿠키가 http://localhost 에 저장되도록
+        // Set-Cookie 의 Secure/Domain 을 제거하고 SameSite 를 Lax 로 맞춘다.
+        configure: (proxy) => {
+          proxy.on("proxyRes", (proxyRes) => {
+            const setCookie = proxyRes.headers["set-cookie"];
+            if (setCookie) {
+              proxyRes.headers["set-cookie"] = setCookie.map((cookie) =>
+                cookie
+                  .replace(/;\s*Secure/gi, "")
+                  .replace(/;\s*Domain=[^;]+/gi, "")
+                  .replace(/;\s*SameSite=None/gi, "; SameSite=Lax"),
+              );
+            }
+          });
+        },
       },
     },
   },

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
     port: 3001,
     proxy: {
       "/api": {
-        target: process.env.VITE_API_PROXY_TARGET || "http://localhost:4000",
+        target: process.env.VITE_API_PROXY_TARGET || "https://api.uosjudo.com",
         changeOrigin: true,
         rewrite: (path) => path,
         secure: false,

--- a/apps/internal/.env.example
+++ b/apps/internal/.env.example
@@ -11,3 +11,5 @@ API_PREFIX=/api/v2/admin
 
 # Vite dev server proxy target for the sidecar (used by vite.config.ts).
 VITE_SIDECAR_TARGET=http://localhost:5174
+# Optional override for browser-side login requests. Defaults to API_BASE_URL.
+VITE_API_PROXY_TARGET=http://localhost:4000

--- a/apps/internal/package.json
+++ b/apps/internal/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.66.11",
+    "archiver": "^7.0.1",
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.9",
+    "@types/archiver": "^6.0.3",
     "@types/express": "^5.0.0",
     "@types/multer": "^1.4.12",
     "@types/node": "^18.19.78",

--- a/apps/internal/server/index.ts
+++ b/apps/internal/server/index.ts
@@ -17,21 +17,66 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
+import archiver from "archiver";
 import express from "express";
 import multer from "multer";
 
+// Node 22 provides loadEnvFile(), but this app still uses Node 18 type definitions.
+const loadEnvFile = (
+  process as NodeJS.Process & { loadEnvFile(path?: string): void }
+).loadEnvFile;
+try {
+  loadEnvFile(fileURLToPath(new URL("../.env", import.meta.url)));
+} catch (error) {
+  if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+}
+
 const PORT = Number(process.env.PORT ?? 5174);
 // Absolute path to the jiho-video-worker checkout.
-const WORKER_DIR = process.env.WORKER_DIR ?? path.resolve(process.cwd(), "../../../jiho-video-worker");
+const WORKER_DIR =
+  process.env.WORKER_DIR ??
+  path.resolve(process.cwd(), "../../../jiho-video-worker");
 // Command that runs Python with the worker deps (uv-managed venv by default).
 const WORKER_BIN = process.env.WORKER_BIN ?? "uv";
 const WORKER_ARGS_PREFIX = (process.env.WORKER_ARGS ?? "run python").split(" ");
 // Real API base + admin v2 prefix.
-const API_BASE_URL = (process.env.API_BASE_URL ?? "http://localhost:4000").replace(/\/$/, "");
+const API_BASE_URL = (
+  process.env.API_BASE_URL ?? "http://localhost:4000"
+).replace(/\/$/, "");
 const API_PREFIX = process.env.API_PREFIX ?? "/api/v2/admin";
 
 const RESULT_PREFIX = "RESULT_JSON:";
+const MAX_ORIGINAL_UPLOAD_BYTES = 60 * 1024 * 1024;
+
+function errorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.cause === undefined
+    ? error.message
+    : `${error.message}: ${errorMessage(error.cause)}`;
+}
+
+class UpstreamError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+async function assertUpstreamResponse(
+  response: Response,
+  operation: string,
+): Promise<void> {
+  if (!response.ok) {
+    throw new UpstreamError(
+      response.status,
+      `${operation} failed (${response.status}): ${await response.text()}`,
+    );
+  }
+}
 
 interface RunnerEvent {
   event_sec: number;
@@ -58,14 +103,25 @@ interface Session {
 
 const sessions = new Map<string, Session>();
 
-const upload = multer({ dest: path.join(os.tmpdir(), "jiho-internal-uploads") });
+const upload = multer({
+  dest: path.join(os.tmpdir(), "jiho-internal-uploads"),
+});
 const app = express();
 app.use(express.json());
 
 /** Run local_runner.py and return its parsed RESULT_JSON. */
-function runWorker(videoPath: string, outputDir: string): Promise<RunnerResult> {
+function runWorker(
+  videoPath: string,
+  outputDir: string,
+): Promise<RunnerResult> {
   return new Promise((resolve, reject) => {
-    const args = [...WORKER_ARGS_PREFIX, "local_runner.py", videoPath, "--output", outputDir];
+    const args = [
+      ...WORKER_ARGS_PREFIX,
+      "local_runner.py",
+      videoPath,
+      "--output",
+      outputDir,
+    ];
     const child = spawn(WORKER_BIN, args, { cwd: WORKER_DIR });
 
     let stdout = "";
@@ -76,7 +132,9 @@ function runWorker(videoPath: string, outputDir: string): Promise<RunnerResult> 
     child.on("error", reject);
     child.on("close", (code) => {
       if (code !== 0) {
-        reject(new Error(`worker exited with code ${code}: ${stderr.slice(-500)}`));
+        reject(
+          new Error(`worker exited with code ${code}: ${stderr.slice(-500)}`),
+        );
         return;
       }
       const line = stdout
@@ -90,7 +148,9 @@ function runWorker(videoPath: string, outputDir: string): Promise<RunnerResult> 
       try {
         resolve(JSON.parse(line.slice(RESULT_PREFIX.length)) as RunnerResult);
       } catch (error) {
-        reject(new Error(`failed to parse RESULT_JSON: ${(error as Error).message}`));
+        reject(
+          new Error(`failed to parse RESULT_JSON: ${(error as Error).message}`),
+        );
       }
     });
   });
@@ -98,7 +158,10 @@ function runWorker(videoPath: string, outputDir: string): Promise<RunnerResult> 
 
 async function readDurationSec(outputDir: string): Promise<number | null> {
   try {
-    const raw = await fsp.readFile(path.join(outputDir, "events.json"), "utf-8");
+    const raw = await fsp.readFile(
+      path.join(outputDir, "events.json"),
+      "utf-8",
+    );
     const parsed = JSON.parse(raw) as { duration_sec?: number };
     return parsed.duration_sec ?? null;
   } catch {
@@ -113,7 +176,9 @@ app.post("/process", upload.single("video"), async (req, res) => {
     return;
   }
 
-  const outputDir = await fsp.mkdtemp(path.join(os.tmpdir(), "jiho-highlights-"));
+  const outputDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "jiho-highlights-"),
+  );
   try {
     const result = await runWorker(file.path, outputDir);
     const durationSec = await readDurationSec(outputDir);
@@ -141,7 +206,7 @@ app.post("/process", upload.single("video"), async (req, res) => {
       })),
     });
   } catch (error) {
-    res.status(500).json({ message: (error as Error).message });
+    res.status(500).json({ message: errorMessage(error) });
   }
 });
 
@@ -157,33 +222,87 @@ app.get("/clip/:sessionId/:index", (req, res) => {
   fs.createReadStream(event.clip_file).pipe(res);
 });
 
+app.get("/download/:sessionId", (req, res) => {
+  const session = sessions.get(req.params.sessionId);
+  if (!session) {
+    res.status(404).json({ message: "session not found" });
+    return;
+  }
+  if (session.events.length === 0) {
+    res.status(400).json({ message: "no highlights to download" });
+    return;
+  }
+
+  const baseName =
+    path
+      .parse(session.originalFilename)
+      .name.replace(/[^a-zA-Z0-9_-]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "video";
+  const archive = archiver("zip", { zlib: { level: 9 } });
+
+  res.attachment(`${baseName}_highlights.zip`);
+  archive.on("error", (error) => {
+    if (!res.headersSent)
+      res.status(500).json({ message: errorMessage(error) });
+    else res.destroy(error);
+  });
+  archive.pipe(res);
+
+  session.events.forEach((event, index) => {
+    archive.file(event.clip_file, {
+      name: `highlight_${String(index + 1).padStart(2, "0")}.mp4`,
+    });
+  });
+  void archive.finalize();
+});
+
 app.post("/upload", async (req, res) => {
-  const { sessionId, uploadOriginal } = req.body as { sessionId?: string; uploadOriginal?: boolean };
+  const { sessionId, uploadOriginal } = req.body as {
+    sessionId?: string;
+    uploadOriginal?: boolean;
+  };
   const session = sessionId ? sessions.get(sessionId) : undefined;
   if (!session) {
     res.status(404).json({ message: "session not found" });
     return;
   }
 
+  const cookie = req.get("cookie");
+  if (!cookie) {
+    res.status(401).json({ message: "관리자 로그인이 필요합니다." });
+    return;
+  }
+
   try {
-    // 1) Create the job + highlight rows.
-    const ingestRes = await fetch(`${API_BASE_URL}${API_PREFIX}/videos/ingest`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        originalFilename: session.originalFilename,
-        durationSec: session.durationSec,
-        events: session.events.map((event) => ({
-          eventSec: event.event_sec,
-          startSec: event.start_sec,
-          endSec: event.end_sec,
-          confidence: event.confidence,
-        })),
-      }),
-    });
-    if (!ingestRes.ok) {
-      throw new Error(`ingest failed (${ingestRes.status}): ${await ingestRes.text()}`);
+    if (uploadOriginal) {
+      const { size } = await fsp.stat(session.tempVideo);
+      if (size > MAX_ORIGINAL_UPLOAD_BYTES) {
+        res.status(413).json({
+          message: "원본 영상은 최대 60MB까지 업로드할 수 있습니다.",
+        });
+        return;
+      }
     }
+
+    // 1) Create the job + highlight rows.
+    const ingestRes = await fetch(
+      `${API_BASE_URL}${API_PREFIX}/videos/ingest`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", cookie },
+        body: JSON.stringify({
+          originalFilename: session.originalFilename,
+          durationSec: session.durationSec,
+          events: session.events.map((event) => ({
+            eventSec: event.event_sec,
+            startSec: event.start_sec,
+            endSec: event.end_sec,
+            confidence: event.confidence,
+          })),
+        }),
+      },
+    );
+    await assertUpstreamResponse(ingestRes, "ingest");
     const ingest = (await ingestRes.json()) as {
       jobId: number;
       highlights: { highlightId: number; index: number }[];
@@ -196,15 +315,21 @@ app.post("/upload", async (req, res) => {
       if (!event) continue;
       const buffer = await fsp.readFile(event.clip_file);
       const form = new FormData();
-      form.append("file", new Blob([buffer], { type: "video/mp4" }), `highlight_${index + 1}.mp4`);
+      form.append(
+        "file",
+        new Blob([buffer], { type: "video/mp4" }),
+        `highlight_${index + 1}.mp4`,
+      );
 
-      const clipRes = await fetch(`${API_BASE_URL}${API_PREFIX}/highlights/${highlightId}/clip`, {
-        method: "POST",
-        body: form,
-      });
-      if (!clipRes.ok) {
-        throw new Error(`clip upload failed (${clipRes.status}): ${await clipRes.text()}`);
-      }
+      const clipRes = await fetch(
+        `${API_BASE_URL}${API_PREFIX}/highlights/${highlightId}/clip`,
+        {
+          method: "POST",
+          headers: { cookie },
+          body: form,
+        },
+      );
+      await assertUpstreamResponse(clipRes, "clip upload");
       uploadedClips += 1;
     }
 
@@ -214,21 +339,28 @@ app.post("/upload", async (req, res) => {
     if (uploadOriginal) {
       const buffer = await fsp.readFile(session.tempVideo);
       const form = new FormData();
-      form.append("file", new Blob([buffer], { type: "video/mp4" }), session.originalFilename);
+      form.append(
+        "file",
+        new Blob([buffer], { type: "video/mp4" }),
+        session.originalFilename,
+      );
 
-      const srcRes = await fetch(`${API_BASE_URL}${API_PREFIX}/videos/${ingest.jobId}/source`, {
-        method: "POST",
-        body: form,
-      });
-      if (!srcRes.ok) {
-        throw new Error(`original upload failed (${srcRes.status}): ${await srcRes.text()}`);
-      }
+      const srcRes = await fetch(
+        `${API_BASE_URL}${API_PREFIX}/videos/${ingest.jobId}/source`,
+        {
+          method: "POST",
+          headers: { cookie },
+          body: form,
+        },
+      );
+      await assertUpstreamResponse(srcRes, "original upload");
       uploadedOriginal = true;
     }
 
     res.json({ jobId: ingest.jobId, uploadedClips, uploadedOriginal });
   } catch (error) {
-    res.status(500).json({ message: (error as Error).message });
+    const status = error instanceof UpstreamError ? error.status : 500;
+    res.status(status).json({ message: errorMessage(error) });
   }
 });
 

--- a/apps/internal/src/App.tsx
+++ b/apps/internal/src/App.tsx
@@ -1,31 +1,66 @@
 import { useRef, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { processVideo, uploadSession, type ProcessResult } from "@/lib/sidecar";
+import LoginView from "@/LoginView";
+import {
+  apiErrorMessage,
+  getAdminSession,
+  logoutAdmin,
+  type AdminProfile,
+} from "@/lib/auth";
+import {
+  downloadHighlights,
+  MAX_ORIGINAL_UPLOAD_BYTES,
+  processVideo,
+  sidecarErrorMessage,
+  uploadSession,
+  type ProcessResult,
+} from "@/lib/sidecar";
+
+const SESSION_QUERY_KEY = ["admin-session"] as const;
 
 function formatSec(value: number): string {
   const total = Math.max(0, Math.round(value));
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m}:${s.toString().padStart(2, "0")}`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export default function App() {
+  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
-  const [progress, setProgress] = useState(0);
+  const [transferProgress, setTransferProgress] = useState(0);
   const [result, setResult] = useState<ProcessResult | null>(null);
   const [uploadOriginal, setUploadOriginal] = useState(false);
 
+  const sessionQuery = useQuery({
+    queryKey: SESSION_QUERY_KEY,
+    queryFn: getAdminSession,
+    retry: false,
+  });
+
   const processMutation = useMutation({
-    mutationFn: (video: File) => processVideo(video, setProgress),
+    mutationFn: (video: File) => processVideo(video, setTransferProgress),
+    onMutate: () => {
+      setResult(null);
+      setTransferProgress(0);
+    },
     onSuccess: (data) => {
       setResult(data);
-      toast.success(`하이라이트 ${data.highlights.length}개 추출 완료`);
+      toast.success(`하이라이트 ${data.highlights.length}개를 추출했습니다.`);
     },
     onError: (error: unknown) => {
-      toast.error(`처리 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`);
+      setTransferProgress(0);
+      toast.error(
+        `처리 실패: ${sidecarErrorMessage(error, "알 수 없는 오류")}`,
+      );
     },
   });
 
@@ -33,106 +68,281 @@ export default function App() {
     mutationFn: (sessionId: string) => uploadSession(sessionId, uploadOriginal),
     onSuccess: (data) => {
       const originalNote = data.uploadedOriginal ? ", 원본 포함" : "";
-      toast.success(`업로드 완료 — job #${data.jobId} (${data.uploadedClips}개 클립${originalNote})`);
+      toast.success(
+        `업로드 완료 — 작업 #${data.jobId}, 클립 ${data.uploadedClips}개${originalNote}`,
+      );
     },
     onError: (error: unknown) => {
-      toast.error(`업로드 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`);
+      toast.error(
+        `업로드 실패: ${sidecarErrorMessage(error, "알 수 없는 오류")}`,
+      );
     },
   });
 
-  const handlePick = () => fileInputRef.current?.click();
+  const logoutMutation = useMutation({
+    mutationFn: logoutAdmin,
+    onSuccess: () => {
+      queryClient.setQueryData<AdminProfile | null>(SESSION_QUERY_KEY, null);
+      setFile(null);
+      setResult(null);
+    },
+    onError: (error) =>
+      toast.error(apiErrorMessage(error, "로그아웃에 실패했습니다.")),
+  });
+
+  if (sessionQuery.isLoading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-50 text-sm text-slate-500">
+        관리자 세션을 확인하고 있습니다…
+      </main>
+    );
+  }
+
+  if (sessionQuery.isError) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-50 px-6">
+        <section className="rounded-xl border border-red-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-sm text-red-700">
+            {apiErrorMessage(
+              sessionQuery.error,
+              "관리자 세션을 확인하지 못했습니다.",
+            )}
+          </p>
+          <button
+            type="button"
+            onClick={() => sessionQuery.refetch()}
+            className="mt-4 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+          >
+            다시 시도
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  if (!sessionQuery.data) {
+    return (
+      <LoginView
+        onLogin={(profile) =>
+          queryClient.setQueryData(SESSION_QUERY_KEY, profile)
+        }
+      />
+    );
+  }
+
+  const profile = sessionQuery.data;
+  const userName = profile.user.additionalInfo?.name || profile.user.email;
+  const isProcessing = processMutation.isPending;
+  const isOriginalTooLarge = !!file && file.size > MAX_ORIGINAL_UPLOAD_BYTES;
+  const processLabel =
+    transferProgress < 100
+      ? `영상 전송 중… ${transferProgress}%`
+      : "로컬 모델이 영상을 분석하고 있습니다…";
 
   const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const picked = event.target.files?.[0] ?? null;
     setFile(picked);
+    if (picked && picked.size > MAX_ORIGINAL_UPLOAD_BYTES) {
+      setUploadOriginal(false);
+    }
     setResult(null);
-    setProgress(0);
+    setTransferProgress(0);
+  };
+
+  const handleDownloadAll = () => {
+    if (!result) return;
+    downloadHighlights(result.sessionId);
+    toast.success("하이라이트 ZIP 다운로드를 시작합니다.");
   };
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
-      <header className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">유도 하이라이트 업로더 (내부용)</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          로컬에서 영상을 처리해 하이라이트만 추출하고, 서버에 업로드합니다.
-        </p>
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-500">
+              UOS Judo
+            </p>
+            <h1 className="mt-1 text-lg font-bold">하이라이트 업로더</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="hidden text-right sm:block">
+              <p className="text-sm font-medium text-slate-700">{userName}</p>
+              <p className="text-xs uppercase text-slate-400">
+                {profile.user.role}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => logoutMutation.mutate()}
+              disabled={logoutMutation.isPending}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-50"
+            >
+              로그아웃
+            </button>
+          </div>
+        </div>
       </header>
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="video/mp4,video/quicktime,video/x-m4v,video/webm"
-          className="hidden"
-          onChange={handleFile}
-        />
+      <main className="mx-auto max-w-5xl px-6 py-8">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <div className="flex items-start gap-4">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-sm font-bold text-white">
+              1
+            </span>
+            <div>
+              <h2 className="font-semibold">로컬 영상 처리</h2>
+              <p className="mt-1 text-sm text-slate-500">
+                영상을 사이드카로 전송한 뒤 로컬 모델로 하이라이트를 추출합니다.
+              </p>
+            </div>
+          </div>
 
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handlePick}
-            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            영상 선택
-          </button>
-          <span className="text-sm text-gray-600">{file ? file.name : "선택된 파일 없음"}</span>
-        </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="video/mp4,video/quicktime,video/x-m4v,video/webm"
+            className="hidden"
+            onChange={handleFile}
+          />
 
-        <button
-          type="button"
-          disabled={!file || processMutation.isPending}
-          onClick={() => file && processMutation.mutate(file)}
-          className="mt-4 w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 hover:bg-indigo-500"
-        >
-          {processMutation.isPending ? `처리 중… ${progress}%` : "로컬 처리 시작"}
-        </button>
-      </section>
-
-      {result && (
-        <section className="mt-8">
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-gray-900">
-              하이라이트 {result.highlights.length}개
-              {result.durationSec != null && (
-                <span className="ml-2 text-sm font-normal text-gray-500">
-                  (영상 길이 {formatSec(result.durationSec)})
-                </span>
-              )}
-            </h2>
-            <div className="flex items-center gap-3">
-              <label className="flex items-center gap-2 text-sm text-gray-600">
-                <input
-                  type="checkbox"
-                  checked={uploadOriginal}
-                  onChange={(e) => setUploadOriginal(e.target.checked)}
-                  className="h-4 w-4 rounded border-gray-300"
-                />
-                원본도 업로드
-              </label>
+          <div className="mt-6 rounded-xl border border-dashed border-slate-300 bg-slate-50 p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-slate-700">
+                  {file ? file.name : "처리할 영상을 선택하세요"}
+                </p>
+                <p className="mt-1 text-xs text-slate-400">
+                  {file ? formatBytes(file.size) : "MP4, MOV, M4V 또는 WebM"}
+                </p>
+              </div>
               <button
                 type="button"
-                disabled={uploadMutation.isPending || result.highlights.length === 0}
-                onClick={() => uploadMutation.mutate(result.sessionId)}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50 hover:bg-emerald-500"
+                disabled={isProcessing}
+                onClick={() => fileInputRef.current?.click()}
+                className="shrink-0 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50"
               >
-                {uploadMutation.isPending ? "업로드 중…" : "서버에 업로드"}
+                영상 선택
               </button>
             </div>
           </div>
 
-          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {result.highlights.map((h) => (
-              <li key={h.index} className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-                <video src={h.clipUrl} controls className="w-full rounded-md bg-black" />
-                <div className="mt-2 flex justify-between text-xs text-gray-600">
-                  <span>이벤트 {formatSec(h.eventSec)}</span>
-                  <span>신뢰도 {h.confidence.toFixed(2)}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <button
+            type="button"
+            disabled={!file || isProcessing}
+            onClick={() => file && processMutation.mutate(file)}
+            className="mt-4 w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isProcessing ? processLabel : "하이라이트 추출 시작"}
+          </button>
         </section>
-      )}
+
+        {result && (
+          <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex items-start gap-4">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-sm font-bold text-white">
+                  2
+                </span>
+                <div>
+                  <h2 className="font-semibold">추출 결과</h2>
+                  <p className="mt-1 text-sm text-slate-500">
+                    하이라이트 {result.highlights.length}개
+                    {result.durationSec != null &&
+                      ` · 원본 ${formatSec(result.durationSec)}`}
+                  </p>
+                </div>
+              </div>
+              {result.highlights.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleDownloadAll}
+                  className="rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100"
+                >
+                  전체 ZIP 다운로드
+                </button>
+              )}
+            </div>
+
+            {result.highlights.length === 0 ? (
+              <p className="mt-6 rounded-xl bg-amber-50 px-4 py-5 text-center text-sm text-amber-800">
+                추출된 하이라이트가 없습니다. 다른 영상을 선택해 다시
+                처리해주세요.
+              </p>
+            ) : (
+              <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {result.highlights.map((highlight) => (
+                  <li
+                    key={highlight.index}
+                    className="overflow-hidden rounded-xl border border-slate-200 bg-white"
+                  >
+                    <video
+                      src={highlight.clipUrl}
+                      controls
+                      preload="metadata"
+                      className="aspect-video w-full bg-black"
+                    />
+                    <div className="flex items-center justify-between gap-3 px-4 py-3 text-xs text-slate-600">
+                      <div>
+                        <p className="font-semibold text-slate-800">
+                          하이라이트 {highlight.index + 1}
+                        </p>
+                        <p className="mt-1">
+                          {formatSec(highlight.startSec)}–
+                          {formatSec(highlight.endSec)} · 신뢰도{" "}
+                          {highlight.confidence.toFixed(2)}
+                        </p>
+                      </div>
+                      <a
+                        href={highlight.clipUrl}
+                        download={`highlight_${highlight.index + 1}.mp4`}
+                        className="shrink-0 font-semibold text-indigo-600 hover:text-indigo-500"
+                      >
+                        다운로드
+                      </a>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-8 border-t border-slate-200 pt-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <label className="flex items-center gap-2 text-sm text-slate-600">
+                  <input
+                    type="checkbox"
+                    checked={uploadOriginal}
+                    disabled={isOriginalTooLarge}
+                    onChange={(event) =>
+                      setUploadOriginal(event.target.checked)
+                    }
+                    className="h-4 w-4 rounded border-slate-300 text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50"
+                  />
+                  원본 영상도 함께 업로드 (최대 60MB)
+                </label>
+                <button
+                  type="button"
+                  disabled={
+                    uploadMutation.isPending || result.highlights.length === 0
+                  }
+                  onClick={() => uploadMutation.mutate(result.sessionId)}
+                  className="rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {uploadMutation.isPending
+                    ? "인증 확인 및 업로드 중…"
+                    : "서버에 업로드"}
+                </button>
+              </div>
+              {isOriginalTooLarge && (
+                <p className="mt-3 text-sm text-amber-700">
+                  선택한 원본이 60MB를 초과해 하이라이트 클립만 업로드할 수
+                  있습니다.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </main>
     </div>
   );
 }

--- a/apps/internal/src/LoginView.tsx
+++ b/apps/internal/src/LoginView.tsx
@@ -1,0 +1,96 @@
+import { FormEvent, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { apiErrorMessage, loginAdmin, type AdminProfile } from "@/lib/auth";
+
+interface LoginViewProps {
+  onLogin: (profile: AdminProfile) => void;
+}
+
+export default function LoginView({ onLogin }: LoginViewProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const loginMutation = useMutation({
+    mutationFn: () => loginAdmin(email.trim(), password),
+    onSuccess: onLogin,
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email.trim() || !password) return;
+    loginMutation.mutate();
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-6 py-12">
+      <section className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-200/60">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-indigo-500">
+          UOS Judo Internal
+        </p>
+        <h1 className="mt-3 text-2xl font-bold tracking-tight text-slate-900">
+          관리자 로그인
+        </h1>
+        <p className="mt-2 text-sm leading-6 text-slate-500">
+          하이라이트 처리와 서버 업로드를 위해 관리자 인증이 필요합니다.
+        </p>
+
+        <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-2 block text-sm font-medium text-slate-700"
+            >
+              이메일
+            </label>
+            <input
+              id="email"
+              autoComplete="username"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="관리자 이메일"
+              className="h-11 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="password"
+              className="mb-2 block text-sm font-medium text-slate-700"
+            >
+              비밀번호
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="비밀번호"
+              className="h-11 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+            />
+          </div>
+
+          {loginMutation.isError && (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {apiErrorMessage(
+                loginMutation.error,
+                "로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.",
+              )}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={!email.trim() || !password || loginMutation.isPending}
+            className="h-11 w-full rounded-lg bg-slate-900 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+          >
+            {loginMutation.isPending ? "로그인 중…" : "로그인"}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/internal/src/lib/auth.ts
+++ b/apps/internal/src/lib/auth.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+
+const adminApi = axios.create({
+  baseURL: "/api/v2/admin",
+  withCredentials: true,
+});
+
+export interface AdminProfile {
+  authenticated: boolean;
+  user: {
+    id: number;
+    email: string;
+    role: string;
+    additionalInfo?: { name?: string | null } | null;
+  };
+}
+
+function isUnauthorized(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 401;
+}
+
+export function apiErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError<{ message?: string }>(error)) {
+    return error.response?.data?.message ?? fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+export async function refreshAdminSession(): Promise<void> {
+  await adminApi.post("/refresh");
+}
+
+export async function getAdminSession(): Promise<AdminProfile | null> {
+  try {
+    const { data } = await adminApi.get<AdminProfile>("/me");
+    return data;
+  } catch (error) {
+    if (!isUnauthorized(error)) throw error;
+  }
+
+  try {
+    await refreshAdminSession();
+    const { data } = await adminApi.get<AdminProfile>("/me");
+    return data;
+  } catch (error) {
+    if (isUnauthorized(error)) return null;
+    throw error;
+  }
+}
+
+export async function loginAdmin(
+  email: string,
+  password: string,
+): Promise<AdminProfile> {
+  await adminApi.post("/login", { email, password });
+  const { data } = await adminApi.get<AdminProfile>("/me");
+  return data;
+}
+
+export async function logoutAdmin(): Promise<void> {
+  await adminApi.post("/logout");
+}

--- a/apps/internal/src/lib/sidecar.ts
+++ b/apps/internal/src/lib/sidecar.ts
@@ -1,7 +1,11 @@
 import axios from "axios";
 
+import { refreshAdminSession } from "@/lib/auth";
+
 // In dev, Vite proxies /sidecar -> the local Node sidecar (see vite.config.ts).
 const sidecar = axios.create({ baseURL: "/sidecar" });
+
+export const MAX_ORIGINAL_UPLOAD_BYTES = 60 * 1024 * 1024;
 
 export interface ProcessedHighlight {
   index: number;
@@ -26,6 +30,13 @@ export interface UploadResult {
   uploadedOriginal: boolean;
 }
 
+export function sidecarErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError<{ message?: string }>(error)) {
+    return error.response?.data?.message ?? fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
 /** Send a local video to the sidecar, which runs the Python worker on it. */
 export async function processVideo(
   file: File,
@@ -45,7 +56,10 @@ export async function processVideo(
   // Prefix preview URLs so the browser hits the proxied sidecar route.
   return {
     ...data,
-    highlights: data.highlights.map((h) => ({ ...h, clipUrl: `/sidecar${h.clipUrl}` })),
+    highlights: data.highlights.map((h) => ({
+      ...h,
+      clipUrl: `/sidecar${h.clipUrl}`,
+    })),
   };
 }
 
@@ -53,7 +67,27 @@ export async function processVideo(
  * Ask the sidecar to upload the processed highlights to the real API.
  * When `uploadOriginal` is true the source video is uploaded too (default false).
  */
-export async function uploadSession(sessionId: string, uploadOriginal = false): Promise<UploadResult> {
-  const { data } = await sidecar.post<UploadResult>("/upload", { sessionId, uploadOriginal });
-  return data;
+export async function uploadSession(
+  sessionId: string,
+  uploadOriginal = false,
+): Promise<UploadResult> {
+  const upload = () =>
+    sidecar.post<UploadResult>("/upload", { sessionId, uploadOriginal });
+
+  try {
+    const { data } = await upload();
+    return data;
+  } catch (error) {
+    if (!axios.isAxiosError(error) || error.response?.status !== 401)
+      throw error;
+    await refreshAdminSession();
+    const { data } = await upload();
+    return data;
+  }
+}
+
+export function downloadHighlights(sessionId: string): void {
+  const link = document.createElement("a");
+  link.href = `/sidecar/download/${encodeURIComponent(sessionId)}`;
+  link.click();
 }

--- a/apps/internal/vite.config.ts
+++ b/apps/internal/vite.config.ts
@@ -2,35 +2,63 @@ import path from "path";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, type ProxyOptions } from "vite";
 
 const srcDir = path.resolve(__dirname, "src");
 
-// The internal app is a local-only tool. The browser talks to the local Node
-// sidecar (which runs the Python worker and forwards uploads to the real API),
-// so we proxy /sidecar to the sidecar process during development.
-const SIDECAR_TARGET = process.env.VITE_SIDECAR_TARGET || "http://localhost:5174";
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const sidecarTarget = env.VITE_SIDECAR_TARGET || "http://localhost:5174";
+  const apiTarget = (
+    env.VITE_API_PROXY_TARGET ||
+    env.API_BASE_URL ||
+    "https://api.uosjudo.com"
+  )
+    .replace(/\/api\/?$/, "")
+    .replace(/\/$/, "");
 
-export default defineConfig({
-  base: "/",
-  plugins: [tailwindcss(), react()],
-  resolve: {
-    alias: {
-      "@": srcDir,
+  const apiProxy: ProxyOptions = {
+    target: apiTarget,
+    changeOrigin: true,
+    secure: false,
+    ws: true,
+    configure: (proxy) => {
+      proxy.on("proxyRes", (proxyRes) => {
+        const setCookie = proxyRes.headers["set-cookie"];
+        if (setCookie) {
+          proxyRes.headers["set-cookie"] = setCookie.map((cookie) =>
+            cookie
+              .replace(/;\s*Secure/gi, "")
+              .replace(/;\s*Domain=[^;]+/gi, "")
+              .replace(/;\s*SameSite=None/gi, "; SameSite=Lax"),
+          );
+        }
+      });
     },
-  },
-  server: {
-    port: 3002,
-    proxy: {
-      "/sidecar": {
-        target: SIDECAR_TARGET,
-        changeOrigin: true,
-        rewrite: (p) => p.replace(/^\/sidecar/, ""),
+  };
+
+  return {
+    base: "/",
+    plugins: [tailwindcss(), react()],
+    resolve: {
+      alias: {
+        "@": srcDir,
       },
     },
-  },
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-  },
+    server: {
+      port: 3002,
+      proxy: {
+        "/api": apiProxy,
+        "/sidecar": {
+          target: sidecarTarget,
+          changeOrigin: true,
+          rewrite: (requestPath) => requestPath.replace(/^\/sidecar/, ""),
+        },
+      },
+    },
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+    },
+  };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.66.11
         version: 5.90.20(react@18.3.1)
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       axios:
         specifier: ^1.3.4
         version: 1.13.4
@@ -226,6 +229,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.9
         version: 4.1.18(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/archiver':
+        specifier: ^6.0.3
+        version: 6.0.4
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -1629,6 +1635,10 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1707,6 +1717,10 @@ packages:
 
   '@orval/zod@8.2.0':
     resolution: {integrity: sha512-r710+ZNxl4AHiIuyh5/T1S3Gx/tGoA5b/ukWtRIsICNuSJpOd2o4Pct4CKWiBIn+Vyv4J0xN9hU2EZeRs0qXBA==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2219,6 +2233,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@types/archiver@6.0.4':
+    resolution: {integrity: sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2357,6 +2374,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -2523,6 +2543,10 @@ packages:
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2608,6 +2632,14 @@ packages:
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -2675,6 +2707,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2699,6 +2734,14 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-plugin-import@1.13.8:
     resolution: {integrity: sha512-36babpjra5m3gca44V6tSTomeBlPA7cHUynrE2WiQIm3rEGD9xy28MKsx5IdO45EbnpJY7Jrgd00C6Dwt/l/2Q==}
@@ -2754,6 +2797,50 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.2:
+    resolution: {integrity: sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.1:
+    resolution: {integrity: sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2798,8 +2885,15 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -2937,6 +3031,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -3000,9 +3098,21 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -3422,8 +3532,19 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -3454,6 +3575,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3541,6 +3665,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -3632,6 +3760,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3791,6 +3924,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore-by-default@1.0.1:
     resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
@@ -4017,6 +4153,9 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -4030,6 +4169,9 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -4124,6 +4266,10 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
 
   leven@4.1.0:
     resolution: {integrity: sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==}
@@ -4236,6 +4382,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -4485,12 +4634,20 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4656,6 +4813,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4709,6 +4869,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4780,6 +4944,13 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4939,9 +5110,19 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -5104,6 +5285,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5286,6 +5470,9 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -5323,6 +5510,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -5402,10 +5592,19 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -5894,6 +6093,10 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -7193,6 +7396,15 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -7348,6 +7560,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7776,6 +7991,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 9.3.4
 
+  '@types/archiver@6.0.4':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -7948,6 +8167,10 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 25.5.0
 
   '@types/semver@7.7.1': {}
 
@@ -8188,6 +8411,10 @@ snapshots:
 
   '@zeit/schemas@2.36.0': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -8261,6 +8488,30 @@ snapshots:
   append-field@1.0.0: {}
 
   arch@2.2.0: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.23
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.2.0
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   arg@5.0.2: {}
 
@@ -8353,6 +8604,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   autoprefixer@10.4.24(postcss@8.5.6):
@@ -8379,6 +8632,8 @@ snapshots:
       - debug
 
   axobject-query@4.1.0: {}
+
+  b4a@1.8.1: {}
 
   babel-plugin-import@1.13.8:
     dependencies:
@@ -8476,6 +8731,41 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.2:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.0.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.1:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.0.1
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   bcp-47-match@2.0.3: {}
@@ -8552,7 +8842,14 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-crc32@1.0.0: {}
+
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   busboy@1.6.0:
     dependencies:
@@ -8680,6 +8977,14 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -8744,6 +9049,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
+  core-util-is@1.0.3: {}
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -8751,6 +9058,13 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.3
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-env@10.1.0:
     dependencies:
@@ -9360,7 +9674,17 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -9472,6 +9796,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9567,6 +9893,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -9659,6 +9990,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -9935,6 +10275,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore-by-default@1.0.1: {}
 
   ignore-styles@5.0.1: {}
@@ -10134,6 +10476,8 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -10148,6 +10492,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jest-diff@29.7.0:
     dependencies:
@@ -10266,6 +10616,10 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   leven@4.1.0: {}
 
   levn@0.4.1:
@@ -10352,6 +10706,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.1:
     optional: true
@@ -10795,11 +11151,17 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mrmime@2.0.1: {}
 
@@ -11007,6 +11369,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -11056,6 +11420,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -11110,6 +11479,10 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -11287,11 +11660,33 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
@@ -11572,6 +11967,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -11810,6 +12207,15 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-argv@0.3.2: {}
 
   string-natural-compare@3.0.1: {}
@@ -11875,6 +12281,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -11942,6 +12352,24 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.2
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -11949,6 +12377,12 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -12413,6 +12847,12 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## 개요
admin 앱에 분석된 영상 하이라이트를 검토·라벨링하는 페이지를 추가합니다.

## 변경 사항
- **목록 페이지** (`/videos`): `GET /api/v2/admin/videos` — job 목록(상태 뱃지, 하이라이트 수)
- **상세/라벨링 페이지** (`/videos/:id`): `GET /api/v2/admin/videos/:jobId` — 하이라이트별 `<video>` 클립 플레이어 + 라벨 폼
- **라벨 저장**: `POST /api/v2/admin/highlights/:highlightId/label`
- 라우트(`RouterUrl.영상`) · LNB 메뉴(Staff 이상) 연결

## 라벨 택소노미
- `techniqueResult`: NONE/ATTEMPT/SUCCESS (필수)
- `score`: NONE/YUKO/WAZA_ARI/IPPON (옵션)
- `technique`(≤100), `highlightScore`(0~10 정수), `correctedEventSec`, `memo`(≤1000) — 모두 옵션

## 구현 메모
- 데이터 패칭/뮤테이션은 orval 생성 `@packages/api` v2Admin 훅 사용
- 도메인 타입은 `@packages/api/model`의 `v2AdminModel` 생성 모델 별칭으로 정의
- 멀티파트 업로드(videos/clip/source) 엔드포인트의 생성 file 타입은 깨져 있으나, 본 화면에서 쓰는 목록/상세/라벨 3개와는 무관

## 검증
- type-check ✅ / lint ✅ / vite build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)