### PR TITLE
feat(internal): 라벨링 결과 JSON 내보내기 (모델 학습용)

### DIFF
--- a/apps/admin/src/features/video/api.ts
+++ b/apps/admin/src/features/video/api.ts
@@ -14,8 +14,8 @@ export type VideoEvent =
 export type VideoHighlight =
   v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItem &
     Pick<VideoEvent, "isLabeledByCurrentUser">;
-export type LatestVideoLabel =
-  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItemLatestLabel;
+export type CurrentUserLabel =
+  v2AdminModel.GetApiV2AdminVideosJobId200JobHighlightsItemCurrentUserLabel;
 
 export type CreateVideoLabelBody =
   v2AdminModel.PostApiV2AdminHighlightsHighlightIdLabelBody;

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -88,7 +88,7 @@ export const HighlightLabelCard = ({
   jobId,
   onSaved,
 }: Props) => {
-  const label = highlight.latestLabel;
+  const label = highlight.currentUserLabel;
   const clipDuration = Math.max(0, highlight.endSec - highlight.startSec);
   const defaultRelativeEventSec =
     label?.correctedEventSec != null

--- a/apps/internal/src/features/labels/api/labels.ts
+++ b/apps/internal/src/features/labels/api/labels.ts
@@ -1,0 +1,85 @@
+import axios from "axios";
+
+import { refreshAdminSession } from "@/features/auth/api/auth";
+
+// In dev, Vite proxies /api -> the backend (see vite.config.ts).
+const api = axios.create({ baseURL: "/api/v2/admin", withCredentials: true });
+
+/** 모델 학습용으로 내보내는 라벨 한 건(라벨 투표 1행 = 하이라이트 + 라벨 값). */
+export interface LabelExportItem {
+  labelId: number;
+  highlightId: number;
+  jobId: number;
+  userId: number | null;
+  techniqueResult: "NONE" | "ATTEMPT" | "SUCCESS";
+  score: "NONE" | "YUKO" | "WAZA_ARI" | "IPPON" | null;
+  technique: string | null;
+  highlightScore: number | null;
+  correctedEventSec: number | null;
+  memo: string | null;
+  eventSec: number;
+  startSec: number;
+  endSec: number;
+  confidence: number;
+  clipUrl: string;
+  originalFilename: string;
+  createdAt: string;
+}
+
+interface LabelsPage {
+  total: number;
+  limit: number;
+  offset: number;
+  items: LabelExportItem[];
+}
+
+const PAGE_SIZE = 500; // 서버 최대 limit
+
+async function getPage(offset: number): Promise<LabelsPage> {
+  const request = () =>
+    api.get<LabelsPage>("/labels", { params: { limit: PAGE_SIZE, offset } });
+
+  try {
+    const { data } = await request();
+    return data;
+  } catch (error) {
+    if (!axios.isAxiosError(error) || error.response?.status !== 401)
+      throw error;
+    await refreshAdminSession();
+    const { data } = await request();
+    return data;
+  }
+}
+
+/**
+ * 전체 라벨을 페이지네이션으로 모두 수집한다(root 권한 필요).
+ * onProgress 로 진행 상황(수집/전체)을 알린다.
+ */
+export async function fetchAllLabels(
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<LabelExportItem[]> {
+  const all: LabelExportItem[] = [];
+  let offset = 0;
+  let total = Number.POSITIVE_INFINITY;
+
+  while (offset < total) {
+    const page = await getPage(offset);
+    total = page.total;
+    all.push(...page.items);
+    offset += page.items.length;
+    onProgress?.(all.length, page.total);
+    if (page.items.length === 0) break; // 안전장치(무한 루프 방지)
+  }
+
+  return all;
+}
+
+export function labelsErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError<{ message?: string }>(error)) {
+    if (error.response?.status === 403) {
+      return "라벨 내보내기는 root 권한에서만 가능합니다.";
+    }
+    return error.response?.data?.message ?? fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}

--- a/apps/internal/src/features/labels/ui/label-export-panel.tsx
+++ b/apps/internal/src/features/labels/ui/label-export-panel.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  fetchAllLabels,
+  labelsErrorMessage,
+  type LabelExportItem,
+} from "@/features/labels/api/labels";
+
+function timestamp(): string {
+  const now = new Date();
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return (
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}`
+  );
+}
+
+function downloadJson(items: LabelExportItem[]): void {
+  const payload = {
+    exportedAt: new Date().toISOString(),
+    total: items.length,
+    items,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `uos-judo-labels-${timestamp()}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function LabelExportPanel() {
+  const [progress, setProgress] = useState<{
+    loaded: number;
+    total: number;
+  } | null>(null);
+
+  const exportMutation = useMutation({
+    mutationFn: () => fetchAllLabels((loaded, total) => setProgress({ loaded, total })),
+    onMutate: () => setProgress(null),
+    onSuccess: (items) => {
+      if (items.length === 0) {
+        toast.info("내보낼 라벨이 아직 없습니다.");
+        return;
+      }
+      downloadJson(items);
+      toast.success(`라벨 ${items.length}건을 내려받았습니다.`);
+    },
+    onError: (error: unknown) =>
+      toast.error(labelsErrorMessage(error, "라벨 내보내기에 실패했습니다.")),
+    onSettled: () => setProgress(null),
+  });
+
+  const isExporting = exportMutation.isPending;
+
+  return (
+    <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <div className="flex items-start gap-4">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white">
+          3
+        </span>
+        <div>
+          <h2 className="font-semibold">라벨 내보내기</h2>
+          <p className="mt-1 text-sm text-slate-500">
+            관리자들이 작성한 라벨링 결과를 JSON 으로 내려받아 jiho-video-worker
+            모델 학습에 사용합니다. (root 권한 필요)
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-slate-500">
+          {isExporting && progress
+            ? `수집 중… ${progress.loaded}/${progress.total}`
+            : "전체 라벨을 한 번에 모아 파일로 저장합니다."}
+        </p>
+        <button
+          type="button"
+          disabled={isExporting}
+          onClick={() => exportMutation.mutate()}
+          className="shrink-0 rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isExporting ? "내보내는 중…" : "라벨 JSON 내보내기"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/internal/src/pages/uploader-page.tsx
+++ b/apps/internal/src/pages/uploader-page.tsx
@@ -7,6 +7,7 @@ import {
 import { isBusy } from "@/features/highlight-queue/lib/format";
 import { QueueList } from "@/features/highlight-queue/ui/queue-list";
 import { UploaderForm } from "@/features/highlight-queue/ui/uploader-form";
+import { LabelExportPanel } from "@/features/labels/ui/label-export-panel";
 
 export function UploaderPage() {
   const queueQuery = useQuery({
@@ -24,6 +25,7 @@ export function UploaderPage() {
     <main className="mx-auto max-w-5xl px-6 py-8">
       <UploaderForm />
       <QueueList items={items} />
+      <LabelExportPanel />
     </main>
   );
 }


### PR DESCRIPTION
## 개요
internal 앱에서 관리자들이 작성한 라벨링 결과를 한 번에 모아 **JSON 파일로 내려받는 기능**을 추가합니다. 받은 파일은 `jiho-video-worker` 모델 학습 데이터로 사용합니다.

## 변경 사항
- **`features/labels/api/labels.ts`**
  - `GET /api/v2/admin/labels` 를 `limit=500` 페이지네이션으로 **전체 수집**(`fetchAllLabels`).
  - 401 시 세션 갱신 후 1회 재시도, 403(root 아님)은 안내 메시지로 변환.
- **`features/labels/ui/label-export-panel.tsx`**
  - uploader-page 에 '라벨 내보내기' 패널 추가. 수집 진행률(`수집 중… n/total`) 표시.
  - `{ exportedAt, total, items }` 형태로 `uos-judo-labels-YYYYMMDD-HHmm.json` 다운로드.
- **`pages/uploader-page.tsx`** — 패널 연결.

## 내보내는 항목(라벨 1행)
labelId, highlightId, jobId, techniqueResult, score, technique, highlightScore, correctedEventSec, memo, eventSec/startSec/endSec, confidence, clipUrl, originalFilename, createdAt

## 참고
- 서버 엔드포인트(`GET /api/v2/admin/labels`, **root 전용**, 페이지네이션/필터)는 이미 구현되어 있어 추가 작업 없음.
- 함께 작업했던 web 로그인 프록시 버그 수정은 #102 에 이미 병합되어 본 PR 에는 포함되지 않음(라벨 기능만).

## 검증
- internal type-check(app+server) ✅ / vite build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)