### PR TITLE
refactor(admin): SegmentedControl을 네이티브 radio + RHF로 개선

### DIFF
--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -394,6 +394,7 @@ function SegmentedRadioGroup<T extends string>({
               "border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50",
               "peer-checked:border-neutral-900 peer-checked:bg-neutral-900 peer-checked:font-semibold peer-checked:text-white",
               "peer-focus-visible:ring-2 peer-focus-visible:ring-neutral-400 peer-focus-visible:ring-offset-1",
+              "hover:peer-checked:bg-neutral-800 hover:peer-checked:text-white",
             )}
           >
             {opt.label}

--- a/apps/admin/src/features/video/ui/highlight-label-card.tsx
+++ b/apps/admin/src/features/video/ui/highlight-label-card.tsx
@@ -4,7 +4,11 @@ import { KebabMenu } from "@/components/ui/kebab-menu";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/shared/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, useForm } from "react-hook-form";
+import {
+  Controller,
+  useForm,
+  type UseFormRegisterReturn,
+} from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import {
@@ -247,30 +251,16 @@ export const HighlightLabelCard = ({
           className="flex flex-col gap-3 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Field label="기술 결과" required>
-            <Controller
-              control={control}
-              name="techniqueResult"
-              render={({ field }) => (
-                <SegmentedControl
-                  options={TECHNIQUE_RESULTS}
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <SegmentedRadioGroup
+              options={TECHNIQUE_RESULTS}
+              registration={register("techniqueResult")}
             />
           </Field>
 
           <Field label="점수">
-            <Controller
-              control={control}
-              name="score"
-              render={({ field }) => (
-                <SegmentedControl
-                  options={SCORES}
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <SegmentedRadioGroup
+              options={SCORES}
+              registration={register("score")}
             />
           </Field>
 
@@ -376,31 +366,39 @@ const Field = ({
   </label>
 );
 
-function SegmentedControl<T extends string>({
+/**
+ * 라디오 그룹처럼 동작하는 세그먼트 컨트롤.
+ * 네이티브 <input type="radio"> 를 RHF register 로 직접 연결해
+ * 키보드/스크린리더 접근성과 폼 검증(zod enum)을 그대로 살린다.
+ */
+function SegmentedRadioGroup<T extends string>({
   options,
-  value,
-  onChange,
+  registration,
 }: {
   options: { value: T; label: string }[];
-  value: T;
-  onChange: (value: T) => void;
+  registration: UseFormRegisterReturn;
 }) {
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div role="radiogroup" className="flex flex-wrap gap-1.5">
       {options.map((opt) => (
-        <button
-          key={opt.value}
-          type="button"
-          onClick={() => onChange(opt.value)}
-          className={cn(
-            "rounded-md border px-3 py-1.5 text-sm transition-colors",
-            value === opt.value
-              ? "border-neutral-900 bg-neutral-900 font-semibold text-white"
-              : "border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50",
-          )}
-        >
-          {opt.label}
-        </button>
+        <label key={opt.value} className="cursor-pointer">
+          <input
+            type="radio"
+            value={opt.value}
+            {...registration}
+            className="peer sr-only"
+          />
+          <span
+            className={cn(
+              "block rounded-md border px-3 py-1.5 text-sm transition-colors",
+              "border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-50",
+              "peer-checked:border-neutral-900 peer-checked:bg-neutral-900 peer-checked:font-semibold peer-checked:text-white",
+              "peer-focus-visible:ring-2 peer-focus-visible:ring-neutral-400 peer-focus-visible:ring-offset-1",
+            )}
+          >
+            {opt.label}
+          </span>
+        </label>
       ))}
     </div>
   );

--- a/apps/admin/src/features/video/ui/technique-select.tsx
+++ b/apps/admin/src/features/video/ui/technique-select.tsx
@@ -168,7 +168,7 @@ export const TechniqueSelect = ({ value, onChange, invalid }: Props) => {
           ) : (
             filteredGroups.map((group) => (
               <div key={group.label}>
-                <p className="sticky top-0 bg-neutral-50 px-3 py-1.5 text-xs font-semibold text-neutral-500">
+                <p className="sticky top-[-4px] bg-neutral-50 px-3 py-1.5 text-xs font-semibold text-neutral-500 border-b border-neutral-200">
                   {group.label}
                 </p>
                 {group.options.map((option) => {


### PR DESCRIPTION
## 개요
`highlight-label-card.tsx` 의 `SegmentedControl`(기술 결과/점수 선택)이 사실상 라디오처럼 동작하는데, `button + onClick + Controller` 조합이라 라디오의 접근성/시맨틱이 없었습니다. 이를 **네이티브 `<input type="radio">` + RHF `register`** 기반의 진짜 라디오 그룹으로 개선했습니다.

## 변경 사항
- `SegmentedControl`(button) → `SegmentedRadioGroup`(radio) 로 교체.
  - `role="radiogroup"` + `<input type="radio">` 를 `register(name)` 로 폼에 직접 연결.
  - 선택 상태는 `peer-checked` CSS 로 표시(시각적 세그먼트 디자인 유지).
  - 키보드 화살표 이동·스크린리더 등 네이티브 라디오 접근성 확보.
- 기술 결과/점수 필드의 `Controller` 래핑 제거 → `register("techniqueResult")` / `register("score")`.
- zod enum 검증, `fieldset disabled`(라벨 완료 시 비활성) 동작은 그대로 유지.

## 비고
- 카드마다 별도 `<form>` 이라 동일 `name` 라디오 그룹이 폼 경계로 격리되어 카드 간 간섭 없음.
- (기술명 선택은 커스텀 `TechniqueSelect` 라 기존대로 `Controller` 유지.)

## 검증
- type-check ✅ / lint ✅ / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)