### PR TITLE
fix: web 배포 복구 (buildx rate limit + SSR 크래시)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -50,6 +50,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          # Use the built-in docker driver so we don't pull moby/buildkit
+          # from Docker Hub (avoids anonymous pull rate-limit failures).
+          driver: docker
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## 배경
`Build and Deploy (apps/Web)`는 그동안 buildx 단계에서 실패해 **실제로 배포된 적이 없었음**. buildx 문제를 고치자 처음으로 배포가 성공했고, 그 순간 잠재해 있던 SSR 크래시가 드러나 **전 도메인이 다운**됨. (백엔드 `api.uosjudo.com`은 정상)

## 1. CI: buildx Docker Hub rate limit
`setup-buildx-action`의 기본 `docker-container` 드라이버가 Docker Hub에서 `moby/buildkit`를 pull → 익명 pull rate limit(`unauthorized: authentication required`)으로 실패. `driver: docker`로 전환해 러너의 기존 BuildKit 사용(이미지 pull 없음). `linux/amd64` 단일 플랫폼 build+push는 이 드라이버에서 정상 지원.

## 2. 런타임: SSR 전면 크래시 `TypeError: (void 0) is not a function`
`entry-server.js`에서 SSR 렌더 중 전 라우트 500.

**원인**: v2Api는 전부 읽기 전용 GET 엔드포인트인데, 공유 orval `query` 설정이 `useQuery`와 함께 `useMutation: true`를 켜둠. **모두 GET인 스펙에서는 orval이 각 오퍼레이션을 mutation으로만 생성**하고 `*QueryOptions`/suspense 훅을 만들지 않음. 그런데 `entry-server.tsx`와 모든 페이지가 query 훅(`getGetApiV2NewsYearQueryOptions`, `useGetApiV2AwardsSuspense` 등)을 호출 → `undefined`를 함수로 호출 → 크래시.

**수정**: orval query 설정을 분리. v2Api는 `useQuery`만(mutation 제거), v2Admin은 쓰기 엔드포인트가 있으므로 둘 다 유지. 생성 코드는 gitignore이며 Docker 빌드의 `pnpm -C packages/api gen`에서 재생성.

## 검증
- `pnpm --filter web build:server`: `IMPORT_IS_UNDEFINED` 경고 사라짐, 빌드 성공
- 전체 빌드 후 프로덕션 SSR 서버 로컬 구동: `/` **200 OK**, 139KB 정상 HTML 렌더, 로그에 `TypeError` 없음
- v2Api: QueryOptions 생성 / v2Admin: mutation 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)