### PR TITLE
ci: 배포 성공 시 도메인별 롤백용 태그 자동 생성

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,68 @@
+name: Tag Release
+
+# 각 배포 파이프라인이 성공적으로 종료되면 해당 도메인(app)에 대한
+# 롤백용 태그를 생성한다.
+#   태그 형식: @uos-judo-jiho/<app>-<YYMMDD>-<6-digit-hash>
+#   예) @uos-judo-jiho/web-260701-c0fdd8
+on:
+  workflow_run:
+    workflows:
+      - "Build and Deploy (apps/Web)"
+      - "Build and Deploy (apps/Admin)"
+      - "Build and Deploy (apps/shorts)"
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    # 배포가 성공했을 때만 태그를 만든다.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout deployed commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Create and push release tag
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # 트리거된 워크플로우 이름 -> app slug 매핑
+          case "$WORKFLOW_NAME" in
+            *"apps/Web"*)    APP="web" ;;
+            *"apps/Admin"*)  APP="admin" ;;
+            *"apps/shorts"*) APP="shorts" ;;
+            *)
+              echo "Unknown workflow name: $WORKFLOW_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          DATE="$(TZ=Asia/Seoul date +%y%m%d)"
+          SHORT_HASH="$(echo "$HEAD_SHA" | cut -c1-6)"
+          TAG="@uos-judo-jiho/${APP}-${DATE}-${SHORT_HASH}"
+
+          echo "Tagging deploy: $TAG (commit $HEAD_SHA)"
+
+          # 같은 커밋을 재배포(re-run)해 태그가 이미 있으면 조용히 종료한다.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists. Skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG" "$HEAD_SHA" \
+            -m "Deploy ${APP} @ ${DATE} (${SHORT_HASH})"
+          git push origin "refs/tags/${TAG}"
+
+          echo "Pushed tag ${TAG}"


### PR DESCRIPTION
## 목적
롤백을 쉽게 하기 위해, 각 배포 파이프라인이 **성공적으로 종료되면** 배포된 커밋에 도메인별 태그를 자동 생성합니다.

## 태그 형식
```
@uos-judo-jiho/<app>-<YYMMDD>-<6-digit-hash>
```
예: `@uos-judo-jiho/web-260701-c0fdd8`

- `app`: web / admin / shorts (트리거된 워크플로우 이름에서 매핑)
- `YYMMDD`: KST(Asia/Seoul) 기준 날짜
- `6-digit-hash`: 배포 커밋 short SHA 6자리

## 동작
- `workflow_run` 이벤트로 `Build and Deploy (apps/Web|Admin|shorts)` 완료를 감지
- `conclusion == 'success'` 일 때만 태그 생성 (실패 배포는 태그 안 함)
- 배포된 커밋(`head_sha`)에 annotated 태그 후 push
- 같은 커밋 재실행 시 태그가 이미 있으면 skip (멱등)
- `permissions: contents: write`

## 롤백 사용 예
```
git checkout @uos-judo-jiho/web-260701-c0fdd8
# 또는 해당 커밋으로 재배포
```

## 검증
- 3개 워크플로우 이름 → app slug 매핑 확인
- `git check-ref-format`로 태그 이름 유효성 확인 (`@`, `/` 포함해도 유효)

🤖 Generated with [Claude Code](https://claude.com/claude-code)