### PR TITLE
ci: 배포 태그에 HHMMSS(KST) 추가

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -2,8 +2,9 @@ name: Tag Release
 
 # 각 배포 파이프라인이 성공적으로 종료되면 해당 도메인(app)에 대한
 # 롤백용 태그를 생성한다.
-#   태그 형식: @uos-judo-jiho/<app>-<YYMMDD>-<6-digit-hash>
-#   예) @uos-judo-jiho/web-260701-c0fdd8
+#   태그 형식: @uos-judo-jiho/<app>-<YYMMDD>-<HHMMSS>-<6-digit-hash>
+#   예) @uos-judo-jiho/web-260701-143052-c0fdd8
+#   (날짜/시각은 KST(Asia/Seoul) 기준)
 on:
   workflow_run:
     workflows:
@@ -47,8 +48,9 @@ jobs:
           esac
 
           DATE="$(TZ=Asia/Seoul date +%y%m%d)"
+          TIME="$(TZ=Asia/Seoul date +%H%M%S)"
           SHORT_HASH="$(echo "$HEAD_SHA" | cut -c1-6)"
-          TAG="@uos-judo-jiho/${APP}-${DATE}-${SHORT_HASH}"
+          TAG="@uos-judo-jiho/${APP}-${DATE}-${TIME}-${SHORT_HASH}"
 
           echo "Tagging deploy: $TAG (commit $HEAD_SHA)"
 
@@ -62,7 +64,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git tag -a "$TAG" "$HEAD_SHA" \
-            -m "Deploy ${APP} @ ${DATE} (${SHORT_HASH})"
+            -m "Deploy ${APP} @ ${DATE} ${TIME} KST (${SHORT_HASH})"
           git push origin "refs/tags/${TAG}"
 
           echo "Pushed tag ${TAG}"


### PR DESCRIPTION
## 변경
롤백 태그에 KST 기준 시각(HHMMSS)을 추가합니다.

**변경 전**
```
@uos-judo-jiho/web-260701-c0fdd8
```
**변경 후**
```
@uos-judo-jiho/web-260701-100043-c0fdd8
        <app>-<YYMMDD>-<HHMMSS>-<hash>
```

## 효과
- 같은 커밋을 여러 번 재배포해도 배포마다 별도 태그로 기록됨
- 태그가 시간순으로 정렬되어 롤백 대상 식별이 쉬움

## 검증
- `git check-ref-format`로 새 태그 이름 유효성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)