### PR TITLE
fix(api): 관리자 로그인 크래시 수정 (orval mutation 훅 복구)

### DIFF
--- a/packages/api/orval.config.ts
+++ b/packages/api/orval.config.ts
@@ -26,22 +26,24 @@ const baseQueryOptions = {
   shouldSplitQueryKey: true,
 } as const;
 
-// NOTE: orval generates a GET operation as a *mutation* (not a query) when
-// `useMutation` is enabled alongside `useQuery`. v2Api is entirely read-only
-// GET endpoints consumed via query/suspense hooks, so it must NOT enable
-// useMutation — otherwise no `*QueryOptions`/suspense hooks are emitted and
-// SSR (and the client) crash with "(void 0) is not a function".
+// NOTE: orval's method-based hook selection is fragile when the useQuery/
+// useMutation booleans are set explicitly:
+//   - `useQuery: true` forces EVERY operation (incl. POST/PUT/DELETE) to be a
+//     query hook → mutations lose `.mutate` ("o.mutate is not a function").
+//   - `useMutation: true` on an all-GET spec forces every GET into a mutation
+//     → no `*QueryOptions`/suspense hooks ("(void 0) is not a function").
+//
+// v2Api is entirely read-only GET endpoints, so we force queries only.
 const apiQueryOptions: QueryOptions = {
   ...baseQueryOptions,
   useQuery: true,
   useMutation: false,
 };
 
-// v2Admin has write endpoints, so it keeps mutation hooks.
+// v2Admin is mixed (GET + write endpoints). Leave useQuery/useMutation unset so
+// orval decides per HTTP method: GET → query/suspense, POST/PUT/DELETE → mutation.
 const adminQueryOptions: QueryOptions = {
   ...baseQueryOptions,
-  useQuery: true,
-  useMutation: true,
 };
 
 export default defineConfig({


### PR DESCRIPTION
## 증상
관리자 페이지 **로그인 시** 크래시:
```
Uncaught (in promise) TypeError: o.mutate is not a function
```

## 원인
`usePostApiV2AdminLogin` 등 v2Admin의 write 엔드포인트가 **mutation이 아니라 query 훅**으로 생성되어 `.mutate`가 없었습니다.

orval은 `useQuery`/`useMutation` 불리언을 **함께 true로 명시**하면 메서드 기반 선택이 깨집니다:
- `useQuery: true` → POST/PUT/DELETE까지 전부 query 훅으로 생성 (`.mutate` 없음)
- (참고: 반대로 all-GET 스펙에 `useMutation: true` → GET이 mutation이 되어 이전 SSR 크래시의 원인이었음)

orval `^8.2.0`이 8.19.0으로 올라오며 이 충돌 동작이 드러났습니다.
(→ tanstack-query 버전 문제가 아니라 orval 생성 설정 문제였습니다. 다운그레이드로는 해결되지 않습니다.)

## 수정
- **v2Admin**(GET+쓰기 혼합): `useQuery`/`useMutation`을 명시하지 않고 orval이 HTTP 메서드로 판단하게 둠 → GET은 query/suspense, POST/PUT/DELETE/PATCH는 mutation.
- **v2Api**(전부 GET): 기존대로 query만 생성 (`useMutation: false`).

## 검증
- 재생성 후 `usePostApiV2AdminLogin` → `useMutation` (`.mutate` 존재) 확인
- `useGetApiV2AdminMe` / `...Suspense` query 훅 정상 생성 확인
- `pnpm -C apps/admin type-check` ✅ · `admin build` ✅ (IMPORT_IS_UNDEFINED 경고 없음)
- web / shorts type-check ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)